### PR TITLE
20 add tool to create a condensed view of collected companions runes and skills to showcase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
 			"name": "cat-hero-tools-frontend",
 			"version": "0.0.0",
 			"dependencies": {
+				"@reduxjs/toolkit": "^2.0.1",
 				"@testing-library/react": "^14.1.2",
 				"jsdom": "^24.0.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
+				"react-redux": "^9.1.0",
 				"react-router-dom": "^6.21.2"
 			},
 			"devDependencies": {
@@ -772,6 +774,29 @@
 			"optional": true,
 			"peer": true
 		},
+		"node_modules/@reduxjs/toolkit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+			"integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+			"dependencies": {
+				"immer": "^10.0.3",
+				"redux": "^5.0.0",
+				"redux-thunk": "^3.1.0",
+				"reselect": "^5.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.9.0 || ^17.0.0 || ^18",
+				"react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-redux": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@remix-run/router": {
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
@@ -1120,6 +1145,11 @@
 			"version": "0.16.8",
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
 			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
+		},
+		"node_modules/@types/use-sync-external-store": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+			"integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
 		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
@@ -3281,6 +3311,15 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/immer": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+			"integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4961,6 +5000,32 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
 		},
+		"node_modules/react-redux": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+			"integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+			"dependencies": {
+				"@types/use-sync-external-store": "^0.0.3",
+				"use-sync-external-store": "^1.0.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.2.25",
+				"react": "^18.0",
+				"react-native": ">=0.69",
+				"redux": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				},
+				"redux": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/react-refresh": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -5034,6 +5099,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redux": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+		},
+		"node_modules/redux-thunk": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+			"peerDependencies": {
+				"redux": "^5.0.0"
+			}
+		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -5088,6 +5166,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+		},
+		"node_modules/reselect": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+			"integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
 		},
 		"node_modules/resolve": {
 			"version": "2.0.0-next.5",
@@ -6458,6 +6541,14 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
 		"coverage": "vitest --coverage"
 	},
 	"dependencies": {
+		"@reduxjs/toolkit": "^2.0.1",
 		"@testing-library/react": "^14.1.2",
 		"jsdom": "^24.0.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-redux": "^9.1.0",
 		"react-router-dom": "^6.21.2"
 	},
 	"devDependencies": {

--- a/src/components/CompanionIcon/CompanionIcon.tsx
+++ b/src/components/CompanionIcon/CompanionIcon.tsx
@@ -22,7 +22,7 @@ export const CompanionIcon = ({ companion, label = true, level = 1 }: { companio
 
 	return (
 		<>
-      <div className='relative w-14 h-14 m-1 z-0 inline-block'>
+      <div className='relative w-14 h-14 z-0 inline-block'>
 				<div className='absolute z-20 left-0 top-0 w-[45%] h-[45%] -translate-x-1/3 -translate-y-1/3'>
 					<div className='relative left-0 top-0'>
 						<img

--- a/src/components/CompanionIcon/CompanionIcon.tsx
+++ b/src/components/CompanionIcon/CompanionIcon.tsx
@@ -1,7 +1,9 @@
 import { getIconBackground } from 'utility/imageHandling/getIconBackground';
+import { ICompanion } from 'types/ICompanion';
 import manaIcon from 'assets/sprites/companions/GV_runeiconeff_1.png';
 
-export const CompanionIcon = ({ companion, label = true, level = 1 }: { companion: any, label?: boolean, level?: number }) => {
+export const CompanionIcon = ({ companion, label = true, level = 1 }: { companion: ICompanion | undefined, label?: boolean, level?: number }) => {
+  if (!companion) return null;
   const background = getIconBackground(companion.rarity);
 	const iconSize = () => {
 		switch (companion.manaCost) {
@@ -20,7 +22,7 @@ export const CompanionIcon = ({ companion, label = true, level = 1 }: { companio
 
 	return (
 		<>
-			<div className='relative w-16 h-16 z-0 inline-block'>
+      <div className='relative w-14 h-14 m-1 z-0 inline-block'>
 				<div className='absolute z-20 left-0 top-0 w-[45%] h-[45%] -translate-x-1/3 -translate-y-1/3'>
 					<div className='relative left-0 top-0'>
 						<img

--- a/src/components/NavigationBar/navigationData.ts
+++ b/src/components/NavigationBar/navigationData.ts
@@ -1,5 +1,6 @@
 import iconMail from 'assets/sprites/ui/GV_icon_speaker.png';
 import iconFace from 'assets/sprites/ui/GV_icon_main_2.png';
+import iconTools from 'assets/sprites/ui/GV_icon_preset.png';
 import { INavigationRoute } from 'types/INavigationRoute';
 
 export const navigationData: INavigationRoute = {
@@ -13,6 +14,11 @@ export const navigationData: INavigationRoute = {
 			displayText: 'Game Data',
 			url: 'game-data',
 			icon: iconFace,
+		},
+		{
+			displayText: 'Tools',
+			url: 'tools',
+			icon: iconTools,
 		},
 	],
 };

--- a/src/components/RuneIcon/RuneIcon.tsx
+++ b/src/components/RuneIcon/RuneIcon.tsx
@@ -24,7 +24,7 @@ export const RuneIcon = ({ rune, label = true }: { rune: IRune | undefined, labe
   const runeImage = setImages()
   return (
     <>
-      <div className='relative w-14 h-14 inline-block m-1'>
+      <div className='relative w-14 h-14 inline-block'>
         {label && <span className='absolute z-10 text-[0.7rem] left-1/2 bottom-0 -translate-x-1/2 translate-y-1/2'>{rune.label}</span>}
         <div className="z-10 relative h-full w-full">{runeImage}</div>
         <img

--- a/src/components/RuneIcon/RuneIcon.tsx
+++ b/src/components/RuneIcon/RuneIcon.tsx
@@ -1,7 +1,8 @@
 import { getRuneBackground } from "utility/imageHandling/getRuneBackground";
 import { IRune } from "types/IRune";
 
-export const RuneIcon = ({ rune, label = true }: { rune: IRune, label?: boolean }) => {
+export const RuneIcon = ({ rune, label = true }: { rune: IRune | undefined, label?: boolean }) => {
+  if (!rune) return null;
 
   const background: string = getRuneBackground(rune.type, rune.rarity);
   const setImages = () => {

--- a/src/components/SkillIcon/SkillIcon.tsx
+++ b/src/components/SkillIcon/SkillIcon.tsx
@@ -7,9 +7,7 @@ export const SkillIcon = ({ skill, label = true, level = 1 }: { skill: ISkill | 
 
   return (
     <>
-      <div className='relative w-14 h-14 inline-block' onClick={() => {
-        console.log(skill.getDescription());
-      }}>
+      <div className='relative w-14 h-14 inline-block'>
         {label && <span className='absolute z-20 text-[0.6rem] left-[4px] top-[2px]'>Lv. {level}</span>}
         <img
           className='absolute z-10 left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 min-w-[40%] min-h-[40%] max-w-[60%] max-h-[60%]'

--- a/src/components/SkillIcon/SkillIcon.tsx
+++ b/src/components/SkillIcon/SkillIcon.tsx
@@ -1,8 +1,8 @@
 import { getIconBackground } from 'utility/imageHandling/getIconBackground';
 import { ISkill } from 'types/ISkill';
 
-export const SkillIcon = ({ skill, label = true, level = 1 }: { skill: ISkill, label?: boolean, level?: number }) => {
-
+export const SkillIcon = ({ skill, label = true, level = 1 }: { skill: ISkill | undefined, label?: boolean, level?: number }) => {
+  if (!skill) return null;
   const background: string = getIconBackground(skill.rarity);
 
   return (

--- a/src/components/SkillIcon/SkillIcon.tsx
+++ b/src/components/SkillIcon/SkillIcon.tsx
@@ -7,7 +7,7 @@ export const SkillIcon = ({ skill, label = true, level = 1 }: { skill: ISkill | 
 
   return (
     <>
-      <div className='relative w-12 h-12 inline-block m-1' onClick={() => {
+      <div className='relative w-14 h-14 inline-block' onClick={() => {
         console.log(skill.getDescription());
       }}>
         {label && <span className='absolute z-20 text-[0.6rem] left-[4px] top-[2px]'>Lv. {level}</span>}

--- a/src/components/SubNavigationBar/SubNavigationBar.tsx
+++ b/src/components/SubNavigationBar/SubNavigationBar.tsx
@@ -4,11 +4,11 @@ import { ILinkRoute, INavigationRoute } from 'types/INavigationRoute';
 const NavigationLink = ({ link }: { link: ILinkRoute }) => {
 	const location = useLocation();
 	const isActive = location.pathname === link.url;
-	const activeClass = isActive ? 'h-14 sub-menu-button-active' : 'h-12 relative -bottom-2';
+  const activeClass = isActive ? 'h-14 sub-menu-button-active bottom-[6px]' : 'h-12 bottom-[-2px]';
 	return (
 		<li className='relative flex mx-[-4px]'>
 			<Link
-				className={`${activeClass} text-center sub-menu-button text-sm flex flex-col items-center  w-20 text-outline`}
+        className={`${activeClass} relative text-center sub-menu-button text-sm flex flex-col items-center  w-20 text-outline`}
 				to={link.url}
 			>
 				{link.icon && (

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -10,15 +10,18 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
 
   return (
     <>
-      <div className="container-light">
-        <div className="flex flex-col lg:flex-row container-dark">
+      <div className="container-light flex flex-row">
+        <div>
+          <div className="flex flex-col lg:flex-row container-dark gap-2">
           <CompanionCollection companionsList={collection.companionsList} />
           <SkillCollection skillsList={collection.skillList} />
         </div>
-        <div className="flex flex-col lg:flex-row container-dark">
+          <div className="flex flex-col lg:flex-row container-dark gap-2">
           <MainRuneCollection runesList={collection.mainRuneList} />
-          <SubRuneCollection runesList={collection.subRuneList} />
+            <SubRuneCollection runesList={collection.subRuneList} />
+          </div>
         </div>
+        <div className="container-dark">equipped display</div>
       </div>
     </>
   );

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -59,7 +59,7 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
       <div className="container-light flex flex-row">
         <div className="w-full">
           <div className="flex flex-row justify-around">
-            <div className="container-dark flex flex-row gap-4 w-full">
+            <div className="container-dark flex flex-col md:flex-row gap-4 w-full">
               <div className=" flex flex-col gap-2 w-full">
                 <CompanionCollection companionsList={collection.companionsList} updateEquipped={updateEquipped} />
 
@@ -68,9 +68,9 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
                   <SubRuneCollection runesList={collection.subRuneList} updateEquipped={updateEquipped} />
                 </div>
               </div>
-              <div className="min-w-[25rem] max-w-[26rem] p-2 gap-6 flex flex-col">
-                <EquippedContainer equipped={equipped} />
+              <div className="md:min-w-[25rem] md:max-w-[26rem] p-2 gap-6 flex flex-col">
                 <SkillCollection skillsList={collection.skillList} updateEquipped={updateEquipped} />
+                <EquippedContainer equipped={equipped} />
               </div>
 
             </div>

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -8,6 +8,8 @@ import { ISelectedSkill } from "../SkillSelection/SkillSelection";
 import { ISelectedCompanion } from "../CompanionSelection/CompanionSelection";
 import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
 import { ISelectedSubRune } from "../SubRuneSelection/SubRuneSelection";
+import { EquippedContainer } from "../EquippedContainer/EquippedContainer";
+
 
 
 export const CollectionContainer = ({ collection }: { collection: ICollection }) => {
@@ -40,19 +42,26 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
     <>
       <div className="container-light flex flex-row">
         <div className="min-w-[30vw]">
-          <div className="flex flex-col lg:flex-row container-dark gap-2 justify-around">
-            <CompanionCollection companionsList={collection.companionsList} updateEquipped={updateEquipped} />
-            <SkillCollection skillsList={collection.skillList} updateEquipped={updateEquipped} />
-          </div>
-          <div className="flex flex-col lg:flex-row container-dark gap-2 justify-around">
-            <MainRuneCollection runesList={collection.mainRuneList} updateEquipped={updateEquipped} />
-            <SubRuneCollection runesList={collection.subRuneList} updateEquipped={updateEquipped} />
+          <div className="flex flex-col lg:flex-rowgap-2 justify-around">
+            <div className="container-dark flex flex-row gap-4">
+              <div className=" flex flex-col gap-2">
+                <CompanionCollection companionsList={collection.companionsList} updateEquipped={updateEquipped} />
+
+                <div className="flex flex-col lg:flex-col gap-2 justify-around">
+                  <MainRuneCollection runesList={collection.mainRuneList} updateEquipped={updateEquipped} />
+                  <SubRuneCollection runesList={collection.subRuneList} updateEquipped={updateEquipped} />
+                </div>
+              </div>
+              <div className="min-w-[25rem] max-w-[26rem] p-2 gap-6 flex flex-col">
+                <EquippedContainer equipped={equipped} />
+                <SkillCollection skillsList={collection.skillList} updateEquipped={updateEquipped} />
+              </div>
+
+            </div>
+
           </div>
         </div>
-        <div className="container-dark min-w-[30vw]">
-          equipped display
-          {JSON.stringify(equipped)}
-        </div>
+
       </div>
     </>
   );

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -58,9 +58,9 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
     <>
       <div className="container-light flex flex-row">
         <div className="w-full">
-          <div className="flex flex-col lg:flex-rowgap-2 justify-around">
-            <div className="container-dark flex flex-row gap-4">
-              <div className=" flex flex-col gap-2">
+          <div className="flex flex-row justify-around">
+            <div className="container-dark flex flex-row gap-4 w-full">
+              <div className=" flex flex-col gap-2 w-full">
                 <CompanionCollection companionsList={collection.companionsList} updateEquipped={updateEquipped} />
 
                 <div className="flex flex-col lg:flex-col gap-2 justify-around">

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -14,12 +14,20 @@ import { EquippedContainer } from "../EquippedContainer/EquippedContainer";
 
 export const CollectionContainer = ({ collection }: { collection: ICollection }) => {
 
-  const [equipped, setEquipped] = useState<ICollection>({
-    companionsList: [],
-    skillList: [],
-    mainRuneList: [],
-    subRuneList: []
-  })
+
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("equipped")
+    if (local) {
+      return JSON.parse(local)
+    }
+    return {
+      companionsList: [],
+      skillList: [],
+      mainRuneList: [],
+      subRuneList: []
+    }
+  }
+  const [equipped, setEquipped] = useState<ICollection>(getLocalStorage())
   const updateEquipped = (type: string, list: ISelectedSkill[] | ISelectedCompanion[] | ISelectedMainRune[] | ISelectedSubRune[]) => {
     switch (type) {
       case "companion":
@@ -38,7 +46,6 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
   }
   useEffect(() => {
     localStorage.setItem("equipped", JSON.stringify(equipped))
-
   }, [equipped])
   useEffect(() => {
     if (localStorage.getItem("equipped")) {

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -3,26 +3,55 @@ import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay
 import { SkillCollection } from "../SkillCollection/SkillCollection";
 import { MainRuneCollection } from "../MainRuneCollection/MainRuneCollection";
 import { SubRuneCollection } from "../SubRuneCollection/SubRuneCollection";
+import { useState } from "react";
+import { ISelectedSkill } from "../SkillSelection/SkillSelection";
+import { ISelectedCompanion } from "../CompanionSelection/CompanionSelection";
+import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
+import { ISelectedSubRune } from "../SubRuneSelection/SubRuneSelection";
 
 
 export const CollectionContainer = ({ collection }: { collection: ICollection }) => {
 
+  const [equipped, setEquipped] = useState<ICollection>({
+    companionsList: [],
+    skillList: [],
+    mainRuneList: [],
+    subRuneList: []
+  })
+  const updateEquipped = (type: string, list: ISelectedSkill[] | ISelectedCompanion[] | ISelectedMainRune[] | ISelectedSubRune[]) => {
+    switch (type) {
+      case "companion":
+        setEquipped({ ...equipped, companionsList: list as ISelectedCompanion[] })
+        break;
+      case "skill":
+        setEquipped({ ...equipped, skillList: list as ISelectedSkill[] })
+        break;
+      case "mainRune":
+        setEquipped({ ...equipped, mainRuneList: list as ISelectedMainRune[] })
+        break;
+      case "subRune":
+        setEquipped({ ...equipped, subRuneList: list as ISelectedSubRune[] })
+        break;
+    }
+
+  }
 
   return (
     <>
       <div className="container-light flex flex-row">
         <div className="min-w-[30vw]">
           <div className="flex flex-col lg:flex-row container-dark gap-2 justify-around">
-            <CompanionCollection companionsList={collection.companionsList} />
-            <SkillCollection skillsList={collection.skillList} />
+            <CompanionCollection companionsList={collection.companionsList} updateEquipped={updateEquipped} />
+            <SkillCollection skillsList={collection.skillList} updateEquipped={updateEquipped} />
           </div>
           <div className="flex flex-col lg:flex-row container-dark gap-2 justify-around">
-            <MainRuneCollection runesList={collection.mainRuneList} />
-            <SubRuneCollection runesList={collection.subRuneList} />
+            <MainRuneCollection runesList={collection.mainRuneList} updateEquipped={updateEquipped} />
+            <SubRuneCollection runesList={collection.subRuneList} updateEquipped={updateEquipped} />
           </div>
         </div>
         <div className="container-dark min-w-[30vw]">
           equipped display
+          {JSON.stringify(equipped)}
         </div>
       </div>
     </>

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -3,7 +3,7 @@ import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay
 import { SkillCollection } from "../SkillCollection/SkillCollection";
 import { MainRuneCollection } from "../MainRuneCollection/MainRuneCollection";
 import { SubRuneCollection } from "../SubRuneCollection/SubRuneCollection";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ISelectedSkill } from "../SkillSelection/SkillSelection";
 import { ISelectedCompanion } from "../CompanionSelection/CompanionSelection";
 import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
@@ -35,13 +35,22 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
         setEquipped({ ...equipped, subRuneList: list as ISelectedSubRune[] })
         break;
     }
-
   }
+  useEffect(() => {
+    localStorage.setItem("equipped", JSON.stringify(equipped))
+
+  }, [equipped])
+  useEffect(() => {
+    if (localStorage.getItem("equipped")) {
+      const equipped = JSON.parse(localStorage.getItem("equipped") || "")
+      setEquipped(equipped)
+    }
+  }, [])
 
   return (
     <>
       <div className="container-light flex flex-row">
-        <div className="min-w-[30vw]">
+        <div className="w-full">
           <div className="flex flex-col lg:flex-rowgap-2 justify-around">
             <div className="container-dark flex flex-row gap-4">
               <div className=" flex flex-col gap-2">

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -1,0 +1,25 @@
+import { CompanionCollection } from "../CompanionCollection/CompanionCollection";
+import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay";
+import { SkillCollection } from "../SkillCollection/SkillCollection";
+import { MainRuneCollection } from "../MainRuneCollection/MainRuneCollection";
+import { SubRuneCollection } from "../SubRuneCollection/SubRuneCollection";
+
+
+export const CollectionContainer = ({ collection }: { collection: ICollection }) => {
+
+
+  return (
+    <>
+      <div className="container-light">
+        <div className="flex flex-col lg:flex-row container-dark">
+          <CompanionCollection companionsList={collection.companionsList} />
+          <SkillCollection skillsList={collection.skillList} />
+        </div>
+        <div className="flex flex-col lg:flex-row container-dark">
+          <MainRuneCollection runesList={collection.mainRuneList} />
+          <SubRuneCollection runesList={collection.subRuneList} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -11,17 +11,19 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
   return (
     <>
       <div className="container-light flex flex-row">
-        <div>
-          <div className="flex flex-col lg:flex-row container-dark gap-2">
-          <CompanionCollection companionsList={collection.companionsList} />
-          <SkillCollection skillsList={collection.skillList} />
-        </div>
-          <div className="flex flex-col lg:flex-row container-dark gap-2">
-          <MainRuneCollection runesList={collection.mainRuneList} />
+        <div className="min-w-[30vw]">
+          <div className="flex flex-col lg:flex-row container-dark gap-2 justify-around">
+            <CompanionCollection companionsList={collection.companionsList} />
+            <SkillCollection skillsList={collection.skillList} />
+          </div>
+          <div className="flex flex-col lg:flex-row container-dark gap-2 justify-around">
+            <MainRuneCollection runesList={collection.mainRuneList} />
             <SubRuneCollection runesList={collection.subRuneList} />
           </div>
         </div>
-        <div className="container-dark">equipped display</div>
+        <div className="container-dark min-w-[30vw]">
+          equipped display
+        </div>
       </div>
     </>
   );

--- a/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/CollectionContainer/CollectionContainer.tsx
@@ -1,58 +1,11 @@
 import { CompanionCollection } from "../CompanionCollection/CompanionCollection";
-import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay";
 import { SkillCollection } from "../SkillCollection/SkillCollection";
 import { MainRuneCollection } from "../MainRuneCollection/MainRuneCollection";
 import { SubRuneCollection } from "../SubRuneCollection/SubRuneCollection";
-import { useEffect, useState } from "react";
-import { ISelectedSkill } from "../SkillSelection/SkillSelection";
-import { ISelectedCompanion } from "../CompanionSelection/CompanionSelection";
-import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
-import { ISelectedSubRune } from "../SubRuneSelection/SubRuneSelection";
 import { EquippedContainer } from "../EquippedContainer/EquippedContainer";
 
 
-
-export const CollectionContainer = ({ collection }: { collection: ICollection }) => {
-
-
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("equipped")
-    if (local) {
-      return JSON.parse(local)
-    }
-    return {
-      companionsList: [],
-      skillList: [],
-      mainRuneList: [],
-      subRuneList: []
-    }
-  }
-  const [equipped, setEquipped] = useState<ICollection>(getLocalStorage())
-  const updateEquipped = (type: string, list: ISelectedSkill[] | ISelectedCompanion[] | ISelectedMainRune[] | ISelectedSubRune[]) => {
-    switch (type) {
-      case "companion":
-        setEquipped({ ...equipped, companionsList: list as ISelectedCompanion[] })
-        break;
-      case "skill":
-        setEquipped({ ...equipped, skillList: list as ISelectedSkill[] })
-        break;
-      case "mainRune":
-        setEquipped({ ...equipped, mainRuneList: list as ISelectedMainRune[] })
-        break;
-      case "subRune":
-        setEquipped({ ...equipped, subRuneList: list as ISelectedSubRune[] })
-        break;
-    }
-  }
-  useEffect(() => {
-    localStorage.setItem("equipped", JSON.stringify(equipped))
-  }, [equipped])
-  useEffect(() => {
-    if (localStorage.getItem("equipped")) {
-      const equipped = JSON.parse(localStorage.getItem("equipped") || "")
-      setEquipped(equipped)
-    }
-  }, [])
+export const CollectionContainer = () => {
 
   return (
     <>
@@ -61,16 +14,16 @@ export const CollectionContainer = ({ collection }: { collection: ICollection })
           <div className="flex flex-row justify-around">
             <div className="container-dark flex flex-col md:flex-row gap-4 w-full">
               <div className=" flex flex-col gap-2 w-full">
-                <CompanionCollection companionsList={collection.companionsList} updateEquipped={updateEquipped} />
+                <CompanionCollection />
 
                 <div className="flex flex-col lg:flex-col gap-2 justify-around">
-                  <MainRuneCollection runesList={collection.mainRuneList} updateEquipped={updateEquipped} />
-                  <SubRuneCollection runesList={collection.subRuneList} updateEquipped={updateEquipped} />
+                  <MainRuneCollection />
+                  <SubRuneCollection />
                 </div>
               </div>
               <div className="md:min-w-[25rem] md:max-w-[26rem] p-2 gap-6 flex flex-col">
-                <SkillCollection skillsList={collection.skillList} updateEquipped={updateEquipped} />
-                <EquippedContainer equipped={equipped} />
+                <SkillCollection />
+                <EquippedContainer />
               </div>
 
             </div>

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -1,26 +1,75 @@
 import { ISelectedCompanion } from "../CompanionSelection/CompanionSelection";
 import { companions } from "src/data/companions/companions";
 import { CompanionIcon } from "src/components/CompanionIcon/CompanionIcon";
+import { useEffect, useState } from "react";
 
+const CompanionBox = ({ companion, add, remove, isEquipped }: { companion: ISelectedCompanion, add: (companion: ISelectedCompanion) => void, remove: (companion: ISelectedCompanion) => void, isEquipped: boolean }) => {
+  const [selected, setSelected] = useState(isEquipped)
+  const selectedClass = selected ? "brightness-125 selected-shadow" : ""
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
 
-export const CompanionCollection = ({ companionsList }: { companionsList: ISelectedCompanion[] }) => {
   const getCompanion = (id: number) => {
     return companions.find((companion) => companion.id === id)
   }
+
+  useEffect(() => {
+    if (selected) {
+      add({ id: companion.id, level: companion.level })
+    } else {
+      remove({ id: companion.id, level: companion.level })
+    }
+  }, [selected])
+  useEffect(() => {
+    setSelected(isEquipped)
+  }, [isEquipped])
+
+
+  return (
+    <div className={`${selectedClass} flex flex-col justify-center items-center w-14`} key={companion.id} onClick={handleSelect}>
+      {selected && <span className="absolute z-10 right-0 top-0 text-2xl">🗸</span>}
+      <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} label={true} />
+    </div>
+  )
+}
+
+export const CompanionCollection = ({ companionsList, updateEquipped }: { companionsList: ISelectedCompanion[], updateEquipped: (type: string, list: ISelectedCompanion[]) => void }) => {
+  const [equippedCompanions, setEquippedCompanions] = useState<ISelectedCompanion[]>([])
+
   const sortById = (a: ISelectedCompanion, b: ISelectedCompanion) => {
     return a.id - b.id
   }
   companionsList.sort(sortById);
 
+  const addToList = (companion: ISelectedCompanion) => {
+    const equippedCompanionList = [...equippedCompanions, companion]
+    if (equippedCompanionList.length > 6) {
+      equippedCompanionList.shift()
+    }
+    setEquippedCompanions(equippedCompanionList)
+  }
+
+  const removeFromList = (companion: ISelectedCompanion) => {
+    setEquippedCompanions(equippedCompanions.filter((obj) => obj.id !== companion.id))
+  }
+
+  const isEquipped = (id: number) => {
+    return equippedCompanions.some((companion) => companion.id === id)
+  }
+
+  useEffect(() => {
+    updateEquipped("companion", equippedCompanions)
+  }, [equippedCompanions])
+
   return (
     <div className="container-dark-inner">
       <h3 className="text-center min-w-48">Companions</h3>
-      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-end">
+      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-end">
         {companionsList.map((companion) => {
+          const isEquippedBool = isEquipped(companion.id)
           return (
-            <div className="flex flex-col justify-center items-center w-14" key={companion.id}>
-              <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} label={true} />
-            </div>
+            <CompanionBox companion={companion} add={addToList} remove={removeFromList} key={companion.id} isEquipped={isEquippedBool} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -63,7 +63,11 @@ export const CompanionCollection = () => {
   }
 
   const removeFromList = (companion: ISelectedCompanion) => {
-    dispatch(setCompanionsList(equippedCompanions.filter((obj) => obj.id !== companion.id)));
+    const equippedCompanionList = [...equippedCompanions]
+    const index = equippedCompanionList.findIndex((obj) => obj.id === companion.id)
+    if (index === -1) return
+    equippedCompanionList[index] = {}
+    dispatch(setCompanionsList(equippedCompanionList));
   }
 
   const isEquipped = (id: number) => {

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -63,9 +63,9 @@ export const CompanionCollection = ({ companionsList, updateEquipped }: { compan
   }, [equippedCompanions])
 
   return (
-    <div className="container-dark-inner">
+    <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Companions</h3>
-      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-end">
+      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-center">
         {companionsList.map((companion) => {
           const isEquippedBool = isEquipped(companion.id)
           return (

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -29,7 +29,7 @@ const CompanionBox = ({ companion, add, remove, isEquipped }: { companion: ISele
     setSelected(isEquipped)
   }, [isEquipped])
 
-
+  if (!companion.id) return null
   return (
     <div className={`${selectedClass} flex flex-col justify-center items-center w-14`} key={companion.id} onClick={handleSelect}>
       {selected && <span className="absolute z-10 right-0 top-0 text-2xl">🗸</span>}
@@ -44,15 +44,21 @@ export const CompanionCollection = () => {
   const equippedCompanions = useSelector((state: RootState) => state.equipmentDisplay.companionsList)
 
   const sortById = (a: ISelectedCompanion, b: ISelectedCompanion) => {
+    if (!a.id || !b.id) return 0
     return a.id - b.id
   }
 
   const addToList = (companion: ISelectedCompanion) => {
     if (equippedCompanions.some((obj) => obj.id === companion.id)) return
-    const equippedCompanionList = [...equippedCompanions, companion]
-    if (equippedCompanionList.length > 6) {
+    const equippedCompanionList = [...equippedCompanions]
+    const indexOfEmpty = equippedCompanionList.findIndex((obj) => !obj.id)
+    if (indexOfEmpty === -1) {
       equippedCompanionList.shift()
+      equippedCompanionList.push(companion)
+    } else {
+      equippedCompanionList[indexOfEmpty] = companion
     }
+
     dispatch(setCompanionsList(equippedCompanionList));
   }
 
@@ -69,6 +75,7 @@ export const CompanionCollection = () => {
       <h3 className="text-center min-w-48">Companions</h3>
       <div className="flex flex-row gap-2 flex-wrap justify-center">
         {companionsList.toSorted(sortById).map((companion, index) => {
+          if (!companion.id) return null
           const isEquippedBool = isEquipped(companion.id)
           return (
             <CompanionBox companion={companion} add={addToList} remove={removeFromList} key={index} isEquipped={isEquippedBool} />

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -1,0 +1,28 @@
+import { ISelectedCompanion } from "../CompanionSelection/CompanionSelection";
+import { companions } from "src/data/companions/companions";
+import { CompanionIcon } from "src/components/CompanionIcon/CompanionIcon";
+
+
+export const CompanionCollection = ({ companionsList }: { companionsList: ISelectedCompanion[] }) => {
+  const getCompanion = (id: number) => {
+    return companions.find((companion) => companion.id === id)
+  }
+  const sortById = (a: ISelectedCompanion, b: ISelectedCompanion) => {
+    return a.id - b.id
+  }
+  companionsList.sort(sortById);
+
+  return (
+    <div className="container-dark-inner">
+      <div className="flex flex-col lg:flex-row gap-1">
+        {companionsList.map((companion) => {
+          return (
+            <div className="flex flex-col justify-center items-center w-14 m-auto" key={companion.id}>
+              <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} label={true} />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -14,10 +14,11 @@ export const CompanionCollection = ({ companionsList }: { companionsList: ISelec
 
   return (
     <div className="container-dark-inner">
-      <div className="flex flex-col lg:flex-row gap-1">
+      <h3 className="text-center min-w-48">Companions</h3>
+      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-end">
         {companionsList.map((companion) => {
           return (
-            <div className="flex flex-col justify-center items-center w-14 m-auto" key={companion.id}>
+            <div className="flex flex-col justify-center items-center w-14" key={companion.id}>
               <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} label={true} />
             </div>
           )

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -72,7 +72,9 @@ export const CompanionCollection = () => {
 
   return (
     <div className="container-dark-inner flex flex-col gap-3">
-      <h3 className="text-center min-w-48">Companions</h3>
+      <h3 className="text-center min-w-48" onClick={() => {
+        console.log(equippedCompanions); console.log(companionsList);
+      }}>Companions</h3>
       <div className="flex flex-row gap-2 flex-wrap justify-center">
         {companionsList.toSorted(sortById).map((companion, index) => {
           if (!companion.id) return null

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -4,6 +4,7 @@ import { CompanionIcon } from "src/components/CompanionIcon/CompanionIcon";
 import { useEffect, useState } from "react";
 
 const CompanionBox = ({ companion, add, remove, isEquipped }: { companion: ISelectedCompanion, add: (companion: ISelectedCompanion) => void, remove: (companion: ISelectedCompanion) => void, isEquipped: boolean }) => {
+
   const [selected, setSelected] = useState(isEquipped)
   const selectedClass = selected ? "brightness-125 selected-shadow" : ""
   const handleSelect = () => {
@@ -35,7 +36,14 @@ const CompanionBox = ({ companion, add, remove, isEquipped }: { companion: ISele
 }
 
 export const CompanionCollection = ({ companionsList, updateEquipped }: { companionsList: ISelectedCompanion[], updateEquipped: (type: string, list: ISelectedCompanion[]) => void }) => {
-  const [equippedCompanions, setEquippedCompanions] = useState<ISelectedCompanion[]>([])
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("equipped")
+    if (local) {
+      return JSON.parse(local).companionsList
+    }
+    return []
+  }
+  const [equippedCompanions, setEquippedCompanions] = useState<ISelectedCompanion[]>(getLocalStorage())
 
   const sortById = (a: ISelectedCompanion, b: ISelectedCompanion) => {
     return a.id - b.id

--- a/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionCollection/CompanionCollection.tsx
@@ -73,7 +73,7 @@ export const CompanionCollection = ({ companionsList, updateEquipped }: { compan
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Companions</h3>
-      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-center">
+      <div className="flex flex-row gap-2 flex-wrap justify-center">
         {companionsList.map((companion) => {
           const isEquippedBool = isEquipped(companion.id)
           return (

--- a/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
@@ -57,7 +57,7 @@ export const CompanionSelection = () => {
   const isSelected = (id: number) => {
     const companion = selectedCompanions.find((companion) => companion.id === id)
     if (!companion) return { selected: false, level: 1 };
-    return { selected: true, level: companion.level }
+    return { selected: true, level: companion.level || 1 }
   }
 
   const companionBoxes = companions.map((companion) => {

--- a/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
@@ -2,11 +2,11 @@ import { companions } from "data/companions/companions"
 import { useEffect, useState } from "react"
 import { CompanionIcon } from "src/components/CompanionIcon/CompanionIcon"
 import { ICompanion } from "src/types/ICompanion"
+import { ISelectedCompanion } from "types/ICollection"
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setCompanionsList } from 'src/config/redux/slices/collectionDisplaySlice'
 
-export interface ISelectedCompanion {
-  id: number,
-  level: number
-}
 const CompanionBox = ({ companion, isSelected, add, remove, update }: { companion: ICompanion, isSelected: { selected: boolean, level: number }, add: (companion: ISelectedCompanion) => void, remove: (companion: ISelectedCompanion) => void, update: (companion: ISelectedCompanion) => void }) => {
   const [level, setLevel] = useState(isSelected.level)
   const [selected, setSelected] = useState(isSelected.selected)
@@ -38,34 +38,21 @@ const CompanionBox = ({ companion, isSelected, add, remove, update }: { companio
 }
 
 
-export const CompanionSelection = ({ setCompanionList }: { setCompanionList: (companionList: ISelectedCompanion[]) => void }) => {
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("companionsList")
-    if (local) {
-      return JSON.parse(local).companionsList
-    }
-    return []
-  }
-  const [selectedCompanions, setSelectedCompanions] = useState<ISelectedCompanion[]>(getLocalStorage())
+export const CompanionSelection = () => {
+  const selectedCompanions = useSelector((state: RootState) => state.collectionDisplay.companionsList)
+  const dispatch = useDispatch();
+
 
   const addToList = (companion: ISelectedCompanion) => {
-    setSelectedCompanions([...selectedCompanions, companion])
-    localStorage.setItem("companionsList", JSON.stringify({ companionsList: [...selectedCompanions, companion] }))
+    dispatch(setCompanionsList([...selectedCompanions, companion]));
   }
 
   const removeFromList = (companion: ISelectedCompanion) => {
-    setSelectedCompanions(selectedCompanions.filter((comp) => comp.id !== companion.id))
-    localStorage.setItem("companionsList", JSON.stringify({ companionsList: selectedCompanions.filter((comp) => comp.id !== companion.id) }))
+    dispatch(setCompanionsList(selectedCompanions.filter((obj) => obj.id !== companion.id)));
   }
 
   const updateList = (companion: ISelectedCompanion) => {
-    setSelectedCompanions(selectedCompanions.map((comp) => {
-      if (comp.id === companion.id) {
-        return companion
-      }
-      return comp
-    }))
-    localStorage.setItem("companionsList", JSON.stringify({ companionsList: selectedCompanions.map((comp) => { if (comp.id === companion.id) { return companion } return comp }) }))
+    dispatch(setCompanionsList(selectedCompanions.map((obj) => obj.id === companion.id ? companion : obj)));
   }
   const isSelected = (id: number) => {
     const companion = selectedCompanions.find((companion) => companion.id === id)
@@ -81,15 +68,12 @@ export const CompanionSelection = ({ setCompanionList }: { setCompanionList: (co
   })
 
 
-  useEffect(() => {
-    setCompanionList(selectedCompanions)
-  }, [selectedCompanions]);
 
 
   return (
     <>
       <div className="container-dark-inner">
-        <h1 className="text-xl" onClick={() => { console.log(selectedCompanions) }}>
+        <h1 className="text-xl">
           Companion Selection
         </h1>
         <div className="flex flex-wrap gap-1">

--- a/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
@@ -1,0 +1,83 @@
+import { companions } from "data/companions/companions"
+import { useEffect, useState } from "react"
+import { CompanionIcon } from "src/components/CompanionIcon/CompanionIcon"
+import { ICompanion } from "src/types/ICompanion"
+
+export interface ISelectedCompanion {
+  id: number,
+  level: number
+}
+const CompanionBox = ({ companion, add, remove, update }: { companion: ICompanion, add: (companion: ISelectedCompanion) => void, remove: (companion: ISelectedCompanion) => void, update: (companion: ISelectedCompanion) => void }) => {
+  const [level, setLevel] = useState(1)
+  const [selected, setSelected] = useState(false)
+  const handleLevelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setLevel(parseInt(event.target.value))
+    update({ id: companion.id, level: parseInt(event.target.value) })
+  }
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: companion.id, level: level })
+    } else {
+      remove({ id: companion.id, level: level })
+    }
+  }, [selected])
+
+  const selectedClass = selected ? "" : "brightness-50"
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`}>
+      <div onClick={handleSelect}>
+        <CompanionIcon companion={companion} level={level} label={true} />
+      </div>
+      <input type="number" name="" id="" value={level} onChange={handleLevelChange} className="w-full z-10 -mt-3" />
+    </div>
+  )
+}
+
+
+export const CompanionSelection = ({ setCompanionList }: { setCompanionList: (companionList: ISelectedCompanion[]) => void }) => {
+  const [selectedCompanions, setSelectedCompanions] = useState<ISelectedCompanion[]>([])
+
+  const addToList = (companion: ISelectedCompanion) => {
+    setSelectedCompanions([...selectedCompanions, companion])
+  }
+
+  const removeFromList = (companion: ISelectedCompanion) => {
+    setSelectedCompanions(selectedCompanions.filter((comp) => comp.id !== companion.id))
+  }
+
+  const updateList = (companion: ISelectedCompanion) => {
+    setSelectedCompanions(selectedCompanions.map((comp) => {
+      if (comp.id === companion.id) {
+        return companion
+      }
+      return comp
+    }))
+  }
+
+  const companionBoxes = companions.map((companion) => {
+    return (
+      <CompanionBox add={addToList} remove={removeFromList} update={updateList} companion={companion} key={companion.id} />
+    )
+  })
+  useEffect(() => {
+    setCompanionList(selectedCompanions)
+  }, [selectedCompanions]);
+
+
+  return (
+    <>
+      <div className="container-dark-inner">
+        <h1 className="text-xl">
+          Companion Selection
+        </h1>
+        <div className="flex flex-wrap gap-1">
+          {companionBoxes}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
+++ b/src/components/ToolsCollectionOverview/CompanionSelection/CompanionSelection.tsx
@@ -7,9 +7,9 @@ export interface ISelectedCompanion {
   id: number,
   level: number
 }
-const CompanionBox = ({ companion, add, remove, update }: { companion: ICompanion, add: (companion: ISelectedCompanion) => void, remove: (companion: ISelectedCompanion) => void, update: (companion: ISelectedCompanion) => void }) => {
-  const [level, setLevel] = useState(1)
-  const [selected, setSelected] = useState(false)
+const CompanionBox = ({ companion, isSelected, add, remove, update }: { companion: ICompanion, isSelected: { selected: boolean, level: number }, add: (companion: ISelectedCompanion) => void, remove: (companion: ISelectedCompanion) => void, update: (companion: ISelectedCompanion) => void }) => {
+  const [level, setLevel] = useState(isSelected.level)
+  const [selected, setSelected] = useState(isSelected.selected)
   const handleLevelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setLevel(parseInt(event.target.value))
     update({ id: companion.id, level: parseInt(event.target.value) })
@@ -39,14 +39,23 @@ const CompanionBox = ({ companion, add, remove, update }: { companion: ICompanio
 
 
 export const CompanionSelection = ({ setCompanionList }: { setCompanionList: (companionList: ISelectedCompanion[]) => void }) => {
-  const [selectedCompanions, setSelectedCompanions] = useState<ISelectedCompanion[]>([])
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("companionsList")
+    if (local) {
+      return JSON.parse(local).companionsList
+    }
+    return []
+  }
+  const [selectedCompanions, setSelectedCompanions] = useState<ISelectedCompanion[]>(getLocalStorage())
 
   const addToList = (companion: ISelectedCompanion) => {
     setSelectedCompanions([...selectedCompanions, companion])
+    localStorage.setItem("companionsList", JSON.stringify({ companionsList: [...selectedCompanions, companion] }))
   }
 
   const removeFromList = (companion: ISelectedCompanion) => {
     setSelectedCompanions(selectedCompanions.filter((comp) => comp.id !== companion.id))
+    localStorage.setItem("companionsList", JSON.stringify({ companionsList: selectedCompanions.filter((comp) => comp.id !== companion.id) }))
   }
 
   const updateList = (companion: ISelectedCompanion) => {
@@ -56,13 +65,22 @@ export const CompanionSelection = ({ setCompanionList }: { setCompanionList: (co
       }
       return comp
     }))
+    localStorage.setItem("companionsList", JSON.stringify({ companionsList: selectedCompanions.map((comp) => { if (comp.id === companion.id) { return companion } return comp }) }))
+  }
+  const isSelected = (id: number) => {
+    const companion = selectedCompanions.find((companion) => companion.id === id)
+    if (!companion) return { selected: false, level: 1 };
+    return { selected: true, level: companion.level }
   }
 
   const companionBoxes = companions.map((companion) => {
+    const isSelectedBool = isSelected(companion.id)
     return (
-      <CompanionBox add={addToList} remove={removeFromList} update={updateList} companion={companion} key={companion.id} />
+      <CompanionBox add={addToList} isSelected={isSelectedBool} remove={removeFromList} update={updateList} companion={companion} key={companion.id} />
     )
   })
+
+
   useEffect(() => {
     setCompanionList(selectedCompanions)
   }, [selectedCompanions]);
@@ -71,7 +89,7 @@ export const CompanionSelection = ({ setCompanionList }: { setCompanionList: (co
   return (
     <>
       <div className="container-dark-inner">
-        <h1 className="text-xl">
+        <h1 className="text-xl" onClick={() => { console.log(selectedCompanions) }}>
           Companion Selection
         </h1>
         <div className="flex flex-wrap gap-1">

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedCompanions/EquippedCompanions.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedCompanions/EquippedCompanions.tsx
@@ -1,16 +1,32 @@
 import { ISelectedCompanion } from "types/ICollection";
 import { companions } from "data/companions/companions";
 import { CompanionIcon } from "components/CompanionIcon/CompanionIcon";
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setCompanionsList } from "src/config/redux/slices/equipmentDisplaySlice";
+
 
 
 const CompanionBox = ({ companion }: { companion: ISelectedCompanion }) => {
+  const dispatch = useDispatch();
+  const equippedCompanions = useSelector((state: RootState) => state.equipmentDisplay.companionsList)
 
   const getCompanion = (id: number) => {
     return companions.find((companion) => companion.id === id)
   }
+  const removeCompanionFromList = () => {
+    const equippedCompanionList = [...equippedCompanions]
+    const index = equippedCompanionList.findIndex((equippedCompanion) => equippedCompanion.id === companion.id)
+    equippedCompanionList[index] = {}
+    dispatch(setCompanionsList(equippedCompanionList));
+  }
+
+  if (!companion.id) return null
   return (
     <>
-      <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} />
+      <div onClick={removeCompanionFromList}>
+        <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} />
+      </div>
     </>
   )
 }
@@ -23,26 +39,18 @@ const EmptySlot = () => {
   )
 }
 
-export const EquippedCompanions = ({ equipped }: { equipped: ISelectedCompanion[] }) => {
-
-
-
+export const EquippedCompanions = () => {
+  const equipped = useSelector((state: RootState) => state.equipmentDisplay.companionsList)
 
   return (
     <>
       <div className="grid grid-cols-6 gap-0">
         {equipped.map((companion, index) => {
+          if (!companion.id) return <EmptySlot key={index} />
           return (
             <CompanionBox key={index} companion={companion} />
           )
         })
-        }
-        {
-          Array(6 - equipped.length).fill(0).map((_, index) => {
-            return (
-              <EmptySlot key={index} />
-            )
-          })
         }
       </div>
     </>

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedCompanions/EquippedCompanions.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedCompanions/EquippedCompanions.tsx
@@ -1,0 +1,50 @@
+import { ISelectedCompanion } from "../../CompanionSelection/CompanionSelection";
+import { companions } from "data/companions/companions";
+import { CompanionIcon } from "components/CompanionIcon/CompanionIcon";
+
+
+const CompanionBox = ({ companion }: { companion: ISelectedCompanion }) => {
+
+  const getCompanion = (id: number) => {
+    return companions.find((companion) => companion.id === id)
+  }
+  return (
+    <>
+      <CompanionIcon companion={getCompanion(companion.id)} level={companion.level} />
+    </>
+  )
+}
+
+const EmptySlot = () => {
+  return (
+    <>
+      <div className="w-12 h-12 container-dark-inner"></div>
+    </>
+  )
+}
+
+export const EquippedCompanions = ({ equipped }: { equipped: ISelectedCompanion[] }) => {
+
+
+
+
+  return (
+    <>
+      <div className="grid grid-cols-6 gap-0">
+        {equipped.map((companion, index) => {
+          return (
+            <CompanionBox key={index} companion={companion} />
+          )
+        })
+        }
+        {
+          Array(6 - equipped.length).fill(0).map((_, index) => {
+            return (
+              <EmptySlot key={index} />
+            )
+          })
+        }
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedCompanions/EquippedCompanions.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedCompanions/EquippedCompanions.tsx
@@ -1,4 +1,4 @@
-import { ISelectedCompanion } from "../../CompanionSelection/CompanionSelection";
+import { ISelectedCompanion } from "types/ICollection";
 import { companions } from "data/companions/companions";
 import { CompanionIcon } from "components/CompanionIcon/CompanionIcon";
 

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedContainer.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedContainer.tsx
@@ -2,24 +2,19 @@ import { EquippedCompanions } from "./EquippedCompanions/EquippedCompanions";
 import { EquippedSkills } from "./EquippedSkills/EquippedSkills";
 import { EquippedMainRunes } from "./EquippedMainRunes/EquippedMainRunes";
 import { EquippedSubRunes } from "./EquippedSubRunes/EquippedSubRunes";
-import { useSelector } from "react-redux";
-import { RootState } from "src/config/redux/store";
-
 
 export const EquippedContainer = () => {
-  const equipped = useSelector((state: RootState) => state.equipmentDisplay)
-
 
   return (
     <>
       <div className="flex flex-col gap-2">
         <div className="flex flex-col gap-2">
-          <EquippedCompanions equipped={equipped.companionsList} />
-          <EquippedSkills equipped={equipped.skillList} />
+          <EquippedCompanions />
+          <EquippedSkills />
         </div>
         <div className="flex flex-row justify-around gap-2">
-          <EquippedMainRunes equipped={equipped.mainRuneList} />
-          <EquippedSubRunes equipped={equipped.subRuneList} />
+          <EquippedMainRunes />
+          <EquippedSubRunes />
         </div>
       </div>
     </>

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedContainer.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedContainer.tsx
@@ -1,0 +1,25 @@
+import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay";
+import { EquippedCompanions } from "./EquippedCompanions/EquippedCompanions";
+import { EquippedSkills } from "./EquippedSkills/EquippedSkills";
+import { EquippedMainRunes } from "./EquippedMainRunes/EquippedMainRunes";
+import { EquippedSubRunes } from "./EquippedSubRunes/EquippedSubRunes";
+
+
+export const EquippedContainer = ({ equipped }: { equipped: ICollection }) => {
+
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2">
+          <EquippedCompanions equipped={equipped.companionsList} />
+          <EquippedSkills equipped={equipped.skillList} />
+        </div>
+        <div className="flex flex-row justify-around gap-2">
+          <EquippedMainRunes equipped={equipped.mainRuneList} />
+          <EquippedSubRunes equipped={equipped.subRuneList} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedContainer.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedContainer.tsx
@@ -1,11 +1,13 @@
-import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay";
 import { EquippedCompanions } from "./EquippedCompanions/EquippedCompanions";
 import { EquippedSkills } from "./EquippedSkills/EquippedSkills";
 import { EquippedMainRunes } from "./EquippedMainRunes/EquippedMainRunes";
 import { EquippedSubRunes } from "./EquippedSubRunes/EquippedSubRunes";
+import { useSelector } from "react-redux";
+import { RootState } from "src/config/redux/store";
 
 
-export const EquippedContainer = ({ equipped }: { equipped: ICollection }) => {
+export const EquippedContainer = () => {
+  const equipped = useSelector((state: RootState) => state.equipmentDisplay)
 
 
   return (

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedMainRunes/EquippedMainRunes.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedMainRunes/EquippedMainRunes.tsx
@@ -1,16 +1,28 @@
 import { ISelectedMainRune } from "types/ICollection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
-
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setMainRuneList } from 'src/config/redux/slices/equipmentDisplaySlice'
 
 const RuneBox = ({ rune }: { rune: ISelectedMainRune }) => {
+  const dispatch = useDispatch();
+  const equippedRunes = useSelector((state: RootState) => state.equipmentDisplay.mainRuneList)
 
   const getRune = (id: number) => {
     return runes.find((rune) => rune.id === id)
   }
+  const removeRuneFromList = () => {
+    const equippedRuneList = [...equippedRunes]
+    const index = equippedRuneList.findIndex((equippedRune) => equippedRune.id === rune.id)
+    equippedRuneList[index] = {}
+    dispatch(setMainRuneList(equippedRuneList));
+  }
+
+  if (!rune.id) return null
   return (
     <>
-      <div className="justify-center flex">
+      <div className="justify-center flex" onClick={removeRuneFromList}>
         <RuneIcon rune={getRune(rune.id)} />
       </div>
     </>
@@ -27,26 +39,17 @@ const EmptySlot = () => {
   )
 }
 
-export const EquippedMainRunes = ({ equipped }: { equipped: ISelectedMainRune[] }) => {
-
-
-
-
+export const EquippedMainRunes = () => {
+  const equipped = useSelector((state: RootState) => state.equipmentDisplay.mainRuneList)
   return (
     <>
       <div className="flex flex-wrap justify-around gap-1 [&>*:first-child]:w-full ">
         {equipped.map((rune, index) => {
+          if (!rune.id) return <EmptySlot key={index} />
           return (
             <RuneBox key={index} rune={rune} />
           )
         })
-        }
-        {
-          Array(3 - equipped.length).fill(0).map((_, index) => {
-            return (
-              <EmptySlot key={index} />
-            )
-          })
         }
       </div>
     </>

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedMainRunes/EquippedMainRunes.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedMainRunes/EquippedMainRunes.tsx
@@ -1,0 +1,54 @@
+import { ISelectedMainRune } from "../../MainRuneSelection/MainRuneSelection";
+import { runes } from "data/runes/runes";
+import { RuneIcon } from "components/RuneIcon/RuneIcon";
+
+
+const RuneBox = ({ rune }: { rune: ISelectedMainRune }) => {
+
+  const getRune = (id: number) => {
+    return runes.find((rune) => rune.id === id)
+  }
+  return (
+    <>
+      <div className="justify-center flex">
+        <RuneIcon rune={getRune(rune.id)} />
+      </div>
+    </>
+  )
+}
+
+const EmptySlot = () => {
+  return (
+    <>
+      <div className=" justify-center flex">
+        <div className="w-14 h-14 bg-[#392d20] border-2 border-black rounded-[50%]"></div>
+      </div>
+    </>
+  )
+}
+
+export const EquippedMainRunes = ({ equipped }: { equipped: ISelectedMainRune[] }) => {
+
+
+
+
+  return (
+    <>
+      <div className="flex flex-wrap justify-around gap-1 [&>*:first-child]:w-full ">
+        {equipped.map((rune, index) => {
+          return (
+            <RuneBox key={index} rune={rune} />
+          )
+        })
+        }
+        {
+          Array(3 - equipped.length).fill(0).map((_, index) => {
+            return (
+              <EmptySlot key={index} />
+            )
+          })
+        }
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedMainRunes/EquippedMainRunes.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedMainRunes/EquippedMainRunes.tsx
@@ -1,4 +1,4 @@
-import { ISelectedMainRune } from "../../MainRuneSelection/MainRuneSelection";
+import { ISelectedMainRune } from "types/ICollection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
 

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSkills/EquippedSkills.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSkills/EquippedSkills.tsx
@@ -1,15 +1,31 @@
 import { SkillIcon } from "src/components/SkillIcon/SkillIcon";
 import { ISelectedSkill } from "types/ICollection";
 import { skills } from "data/skills/skills";
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSkillList } from 'src/config/redux/slices/equipmentDisplaySlice'
 
 const SkillBox = ({ skill }: { skill: ISelectedSkill }) => {
+  const dispatch = useDispatch();
+  const equippedSkills = useSelector((state: RootState) => state.equipmentDisplay.skillList)
+
 
   const getSkill = (id: number) => {
     return skills.find((skill) => skill.id === id)
   }
+  const removeSkillFromList = () => {
+    const equippedSkillList = [...equippedSkills]
+    const index = equippedSkillList.findIndex((equippedSkill) => equippedSkill.id === skill.id)
+    equippedSkillList[index] = {}
+    dispatch(setSkillList(equippedSkillList));
+  }
+
+  if (!skill.id) return null
   return (
     <>
-      <SkillIcon skill={getSkill(skill.id)} level={skill.level} />
+      <div onClick={removeSkillFromList}>
+        <SkillIcon skill={getSkill(skill.id)} level={skill.level} />
+      </div>
     </>
   )
 }
@@ -22,26 +38,18 @@ const EmptySlot = () => {
   )
 }
 
-export const EquippedSkills = ({ equipped }: { equipped: ISelectedSkill[] }) => {
-
-
-
+export const EquippedSkills = () => {
+  const equipped = useSelector((state: RootState) => state.equipmentDisplay.skillList)
 
   return (
     <>
       <div className="grid grid-cols-6">
         {equipped.map((skill, index) => {
+          if (!skill.id) return <EmptySlot key={index} />
           return (
             <SkillBox key={index} skill={skill} />
           )
         })
-        }
-        {
-          Array(6 - equipped.length).fill(0).map((_, index) => {
-            return (
-              <EmptySlot key={index} />
-            )
-          })
         }
       </div>
     </>

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSkills/EquippedSkills.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSkills/EquippedSkills.tsx
@@ -1,5 +1,5 @@
 import { SkillIcon } from "src/components/SkillIcon/SkillIcon";
-import { ISelectedSkill } from "../../SkillSelection/SkillSelection";
+import { ISelectedSkill } from "types/ICollection";
 import { skills } from "data/skills/skills";
 
 const SkillBox = ({ skill }: { skill: ISelectedSkill }) => {

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSkills/EquippedSkills.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSkills/EquippedSkills.tsx
@@ -1,0 +1,49 @@
+import { SkillIcon } from "src/components/SkillIcon/SkillIcon";
+import { ISelectedSkill } from "../../SkillSelection/SkillSelection";
+import { skills } from "data/skills/skills";
+
+const SkillBox = ({ skill }: { skill: ISelectedSkill }) => {
+
+  const getSkill = (id: number) => {
+    return skills.find((skill) => skill.id === id)
+  }
+  return (
+    <>
+      <SkillIcon skill={getSkill(skill.id)} level={skill.level} />
+    </>
+  )
+}
+
+const EmptySlot = () => {
+  return (
+    <>
+      <div className="w-12 h-12 container-dark-inner"></div>
+    </>
+  )
+}
+
+export const EquippedSkills = ({ equipped }: { equipped: ISelectedSkill[] }) => {
+
+
+
+
+  return (
+    <>
+      <div className="grid grid-cols-6">
+        {equipped.map((skill, index) => {
+          return (
+            <SkillBox key={index} skill={skill} />
+          )
+        })
+        }
+        {
+          Array(6 - equipped.length).fill(0).map((_, index) => {
+            return (
+              <EmptySlot key={index} />
+            )
+          })
+        }
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSubRunes/EquippedSubRunes.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSubRunes/EquippedSubRunes.tsx
@@ -1,16 +1,28 @@
 import { ISelectedSubRune } from "types/ICollection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSubRuneList } from 'src/config/redux/slices/equipmentDisplaySlice'
 
 
 const RuneBox = ({ rune }: { rune: ISelectedSubRune }) => {
+  const dispatch = useDispatch();
+  const equippedRunes = useSelector((state: RootState) => state.equipmentDisplay.subRuneList)
 
   const getRune = (id: number) => {
     return runes.find((rune) => rune.id === id)
   }
+  const removeRuneFromList = () => {
+    const equippedRuneList = [...equippedRunes]
+    const index = equippedRuneList.findIndex((equippedRune) => equippedRune.id === rune.id)
+    equippedRuneList[index] = {}
+    dispatch(setSubRuneList(equippedRuneList));
+  }
+  if (!rune.id) return null
   return (
     <>
-      <div className="justify-center flex">
+      <div className="justify-center flex" onClick={removeRuneFromList}>
         <RuneIcon rune={getRune(rune.id)} />
       </div>
     </>
@@ -29,26 +41,17 @@ const EmptySlot = () => {
   )
 }
 
-export const EquippedSubRunes = ({ equipped }: { equipped: ISelectedSubRune[] }) => {
-
-
-
-
+export const EquippedSubRunes = () => {
+  const equipped = useSelector((state: RootState) => state.equipmentDisplay.subRuneList)
   return (
     <>
       <div className="grid grid-cols-2 grid-rows-2 gap-1 [&>*:first-child]:w-full ">
         {equipped.map((rune, index) => {
+          if (!rune.id) return <EmptySlot key={index} />
           return (
             <RuneBox key={index} rune={rune} />
           )
         })
-        }
-        {
-          Array(4 - equipped.length).fill(0).map((_, index) => {
-            return (
-              <EmptySlot key={index} />
-            )
-          })
         }
       </div>
     </>

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSubRunes/EquippedSubRunes.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSubRunes/EquippedSubRunes.tsx
@@ -1,4 +1,4 @@
-import { ISelectedSubRune } from "../../SubRuneSelection/SubRuneSelection";
+import { ISelectedSubRune } from "types/ICollection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
 

--- a/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSubRunes/EquippedSubRunes.tsx
+++ b/src/components/ToolsCollectionOverview/EquippedContainer/EquippedSubRunes/EquippedSubRunes.tsx
@@ -1,0 +1,56 @@
+import { ISelectedSubRune } from "../../SubRuneSelection/SubRuneSelection";
+import { runes } from "data/runes/runes";
+import { RuneIcon } from "components/RuneIcon/RuneIcon";
+
+
+const RuneBox = ({ rune }: { rune: ISelectedSubRune }) => {
+
+  const getRune = (id: number) => {
+    return runes.find((rune) => rune.id === id)
+  }
+  return (
+    <>
+      <div className="justify-center flex">
+        <RuneIcon rune={getRune(rune.id)} />
+      </div>
+    </>
+  )
+}
+
+const EmptySlot = () => {
+  return (
+    <>
+      <div className="justify-center flex">
+        <div className="w-14 h-14 bg-[#392d20] border-2 border-black rounded-[50%]">
+
+        </div>
+      </div>
+    </>
+  )
+}
+
+export const EquippedSubRunes = ({ equipped }: { equipped: ISelectedSubRune[] }) => {
+
+
+
+
+  return (
+    <>
+      <div className="grid grid-cols-2 grid-rows-2 gap-1 [&>*:first-child]:w-full ">
+        {equipped.map((rune, index) => {
+          return (
+            <RuneBox key={index} rune={rune} />
+          )
+        })
+        }
+        {
+          Array(4 - equipped.length).fill(0).map((_, index) => {
+            return (
+              <EmptySlot key={index} />
+            )
+          })
+        }
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -14,7 +14,8 @@ export const MainRuneCollection = ({ runesList }: { runesList: ISelectedMainRune
 
   return (
     <div className="container-dark-inner">
-      <div className="flex flex-col lg:flex-row gap-1">
+      <h3 className="text-center min-w-48">Main Runes</h3>
+      <div className="flex flex-col lg:flex-row gap-1 flex-wrap">
         {runesList.map((rune) => {
           return (
             <div className="flex flex-col justify-center items-center w-14 m-auto" key={rune.id}>

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -1,7 +1,10 @@
-import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
+import { ISelectedMainRune } from "types/ICollection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
 import { useEffect, useState } from "react";
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setMainRuneList } from 'src/config/redux/slices/equipmentDisplaySlice'
 
 
 const MainRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedMainRune, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void, isEquipped: boolean }) => {
@@ -38,47 +41,38 @@ const MainRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedMainRun
 }
 
 
-export const MainRuneCollection = ({ runesList, updateEquipped }: { runesList: ISelectedMainRune[], updateEquipped: (type: string, list: ISelectedMainRune[]) => void }) => {
-
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("equipped")
-    if (local) {
-      return JSON.parse(local).mainRuneList
-    }
-    return []
-  }
-  const [equippedRunes, setEquippedRunes] = useState<ISelectedMainRune[]>(getLocalStorage())
+export const MainRuneCollection = () => {
+  const dispatch = useDispatch();
+  const runesList = useSelector((state: RootState) => state.collectionDisplay.mainRuneList)
+  const equippedRunes = useSelector((state: RootState) => state.equipmentDisplay.mainRuneList)
 
   const sortById = (a: ISelectedMainRune, b: ISelectedMainRune) => {
     return a.id - b.id
   }
-  runesList.sort(sortById);
 
   const addToList = (rune: ISelectedMainRune) => {
+    if (equippedRunes.some((obj) => obj.id === rune.id)) return
     const equippedRuneList = [...equippedRunes, rune]
     if (equippedRuneList.length > 3) {
       equippedRuneList.shift()
     }
-    setEquippedRunes(equippedRuneList)
+    dispatch(setMainRuneList(equippedRuneList));
   }
   const removeFromList = (rune: ISelectedMainRune) => {
-    setEquippedRunes(equippedRunes.filter((obj) => obj.id !== rune.id))
+    dispatch(setMainRuneList(equippedRunes.filter((obj) => obj.id !== rune.id)));
   }
   const isEquipped = (id: number) => {
     return equippedRunes.some((rune) => rune.id === id)
   }
-  useEffect(() => {
-    updateEquipped("mainRune", equippedRunes)
-  }, [equippedRunes])
 
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Main Runes</h3>
       <div className="flex flex-row gap-1 flex-wrap justify-center">
-        {runesList.map((rune) => {
+        {runesList.toSorted(sortById).map((rune, index) => {
           const isEquippedBool = isEquipped(rune.id)
           return (
-            <MainRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={rune.id} />
+            <MainRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={index} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -27,7 +27,7 @@ const MainRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedMainRun
   useEffect(() => {
     setSelected(isEquipped)
   }, [isEquipped])
-
+  if (!rune.id) return null
   return (
     <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
       {selected && <>
@@ -47,14 +47,19 @@ export const MainRuneCollection = () => {
   const equippedRunes = useSelector((state: RootState) => state.equipmentDisplay.mainRuneList)
 
   const sortById = (a: ISelectedMainRune, b: ISelectedMainRune) => {
+    if (!a.id || !b.id) return 0
     return a.id - b.id
   }
 
   const addToList = (rune: ISelectedMainRune) => {
     if (equippedRunes.some((obj) => obj.id === rune.id)) return
-    const equippedRuneList = [...equippedRunes, rune]
-    if (equippedRuneList.length > 3) {
+    const equippedRuneList = [...equippedRunes]
+    const indexOfEmpty = equippedRuneList.findIndex((obj) => !obj.id)
+    if (indexOfEmpty === -1) {
       equippedRuneList.shift()
+      equippedRuneList.push(rune)
+    } else {
+      equippedRuneList[indexOfEmpty] = rune
     }
     dispatch(setMainRuneList(equippedRuneList));
   }
@@ -70,6 +75,7 @@ export const MainRuneCollection = () => {
       <h3 className="text-center min-w-48">Main Runes</h3>
       <div className="flex flex-row gap-1 flex-wrap justify-center">
         {runesList.toSorted(sortById).map((rune, index) => {
+          if (!rune.id) return null
           const isEquippedBool = isEquipped(rune.id)
           return (
             <MainRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={index} />

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -29,7 +29,7 @@ const MainRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedMainRun
     <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
       {selected && <>
         <span className="absolute z-10 right-0 -top-1 text-2xl">🗸</span>
-        <div className=" rounded-[50%] selected-shadow-circle border-2 border-red-400 w-14 h-14 top-1 absolute"></div>
+        <div className=" rounded-[50%] selected-shadow-circle border-2 border-red-400 w-14 h-14 top-0 absolute"></div>
       </>}
       <RuneIcon rune={getRune(rune.id)} label={true} />
     </div>
@@ -64,9 +64,9 @@ export const MainRuneCollection = ({ runesList, updateEquipped }: { runesList: I
   }, [equippedRunes])
 
   return (
-    <div className="container-dark-inner">
+    <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Main Runes</h3>
-      <div className="flex flex-col lg:flex-row gap-1 flex-wrap">
+      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-center">
         {runesList.map((rune) => {
           const isEquippedBool = isEquipped(rune.id)
           return (

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -64,7 +64,11 @@ export const MainRuneCollection = () => {
     dispatch(setMainRuneList(equippedRuneList));
   }
   const removeFromList = (rune: ISelectedMainRune) => {
-    dispatch(setMainRuneList(equippedRunes.filter((obj) => obj.id !== rune.id)));
+    const equippedRuneList = [...equippedRunes]
+    const index = equippedRuneList.findIndex((obj) => obj.id === rune.id)
+    if (index === -1) return
+    equippedRuneList[index] = {}
+    dispatch(setMainRuneList(equippedRuneList));
   }
   const isEquipped = (id: number) => {
     return equippedRunes.some((rune) => rune.id === id)

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -74,7 +74,7 @@ export const MainRuneCollection = ({ runesList, updateEquipped }: { runesList: I
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Main Runes</h3>
-      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-center">
+      <div className="flex flex-row gap-1 flex-wrap justify-center">
         {runesList.map((rune) => {
           const isEquippedBool = isEquipped(rune.id)
           return (

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -1,0 +1,28 @@
+import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
+import { runes } from "data/runes/runes";
+import { RuneIcon } from "components/RuneIcon/RuneIcon";
+
+
+export const MainRuneCollection = ({ runesList }: { runesList: ISelectedMainRune[] }) => {
+  const getRune = (id: number) => {
+    return runes.find((rune) => rune.id === id)
+  }
+  const sortById = (a: ISelectedMainRune, b: ISelectedMainRune) => {
+    return a.id - b.id
+  }
+  runesList.sort(sortById);
+
+  return (
+    <div className="container-dark-inner">
+      <div className="flex flex-col lg:flex-row gap-1">
+        {runesList.map((rune) => {
+          return (
+            <div className="flex flex-col justify-center items-center w-14 m-auto" key={rune.id}>
+              <RuneIcon rune={getRune(rune.id)} label={true} />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -48,7 +48,7 @@ export const MainRuneCollection = ({ runesList, updateEquipped }: { runesList: I
 
   const addToList = (rune: ISelectedMainRune) => {
     const equippedRuneList = [...equippedRunes, rune]
-    if (equippedRuneList.length > 6) {
+    if (equippedRuneList.length > 3) {
       equippedRuneList.shift()
     }
     setEquippedRunes(equippedRuneList)

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -39,7 +39,15 @@ const MainRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedMainRun
 
 
 export const MainRuneCollection = ({ runesList, updateEquipped }: { runesList: ISelectedMainRune[], updateEquipped: (type: string, list: ISelectedMainRune[]) => void }) => {
-  const [equippedRunes, setEquippedRunes] = useState<ISelectedMainRune[]>([])
+
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("equipped")
+    if (local) {
+      return JSON.parse(local).mainRuneList
+    }
+    return []
+  }
+  const [equippedRunes, setEquippedRunes] = useState<ISelectedMainRune[]>(getLocalStorage())
 
   const sortById = (a: ISelectedMainRune, b: ISelectedMainRune) => {
     return a.id - b.id

--- a/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneCollection/MainRuneCollection.tsx
@@ -1,26 +1,76 @@
 import { ISelectedMainRune } from "../MainRuneSelection/MainRuneSelection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
+import { useEffect, useState } from "react";
 
 
-export const MainRuneCollection = ({ runesList }: { runesList: ISelectedMainRune[] }) => {
+const MainRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedMainRune, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void, isEquipped: boolean }) => {
+  const [selected, setSelected] = useState(isEquipped)
+  const selectedClass = selected ? "brightness-125" : ""
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: rune.id })
+    } else {
+      remove({ id: rune.id })
+    }
+  }, [selected])
+
   const getRune = (id: number) => {
     return runes.find((rune) => rune.id === id)
   }
+  useEffect(() => {
+    setSelected(isEquipped)
+  }, [isEquipped])
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
+      {selected && <>
+        <span className="absolute z-10 right-0 -top-1 text-2xl">🗸</span>
+        <div className=" rounded-[50%] selected-shadow-circle border-2 border-red-400 w-14 h-14 top-1 absolute"></div>
+      </>}
+      <RuneIcon rune={getRune(rune.id)} label={true} />
+    </div>
+  )
+
+}
+
+
+export const MainRuneCollection = ({ runesList, updateEquipped }: { runesList: ISelectedMainRune[], updateEquipped: (type: string, list: ISelectedMainRune[]) => void }) => {
+  const [equippedRunes, setEquippedRunes] = useState<ISelectedMainRune[]>([])
+
   const sortById = (a: ISelectedMainRune, b: ISelectedMainRune) => {
     return a.id - b.id
   }
   runesList.sort(sortById);
+
+  const addToList = (rune: ISelectedMainRune) => {
+    const equippedRuneList = [...equippedRunes, rune]
+    if (equippedRuneList.length > 6) {
+      equippedRuneList.shift()
+    }
+    setEquippedRunes(equippedRuneList)
+  }
+  const removeFromList = (rune: ISelectedMainRune) => {
+    setEquippedRunes(equippedRunes.filter((obj) => obj.id !== rune.id))
+  }
+  const isEquipped = (id: number) => {
+    return equippedRunes.some((rune) => rune.id === id)
+  }
+  useEffect(() => {
+    updateEquipped("mainRune", equippedRunes)
+  }, [equippedRunes])
 
   return (
     <div className="container-dark-inner">
       <h3 className="text-center min-w-48">Main Runes</h3>
       <div className="flex flex-col lg:flex-row gap-1 flex-wrap">
         {runesList.map((rune) => {
+          const isEquippedBool = isEquipped(rune.id)
           return (
-            <div className="flex flex-col justify-center items-center w-14 m-auto" key={rune.id}>
-              <RuneIcon rune={getRune(rune.id)} label={true} />
-            </div>
+            <MainRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={rune.id} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
@@ -2,23 +2,34 @@ import { runes } from "data/runes/runes"
 import { useEffect, useState } from "react"
 import { RuneIcon } from "src/components/RuneIcon/RuneIcon"
 import { IRune } from "src/types/IRune"
-import { ISelectedMainRune } from "types/ICollection"
 import type { RootState } from 'src/config/redux/store'
 import { useSelector, useDispatch } from 'react-redux'
 import { setMainRuneList } from 'src/config/redux/slices/collectionDisplaySlice'
 
-const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: { selected: boolean }, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void }) => {
-  const [selected, setSelected] = useState(isSelected.selected)
+const RuneBox = ({ rune }: { rune: IRune }) => {
+  const dispatch = useDispatch();
+  const selectedRunes = useSelector((state: RootState) => state.collectionDisplay.mainRuneList)
+  const isSelected = selectedRunes.some((obj) => obj.id === rune.id)
+  const runeFromList = selectedRunes.find((obj) => obj.id === rune.id)
+  const [selected, setSelected] = useState(isSelected)
   const handleSelect = () => {
     setSelected(!selected)
   }
   useEffect(() => {
     if (selected) {
-      add({ id: rune.id })
+      if (runeFromList) {
+        dispatch(setMainRuneList(selectedRunes.map((obj) => obj.id === rune.id ? { id: rune.id } : obj)));
+      } else {
+        dispatch(setMainRuneList([...selectedRunes, { id: rune.id }]));
+      }
     } else {
-      remove({ id: rune.id })
+      dispatch(setMainRuneList(selectedRunes.filter((obj) => obj.id !== rune.id)));
     }
   }, [selected])
+
+  useEffect(() => {
+    setSelected(isSelected)
+  }, [isSelected])
 
   const selectedClass = selected ? "" : "brightness-50"
 
@@ -33,30 +44,12 @@ const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: {
 
 
 export const MainRuneSelection = () => {
-  const selectedRunes = useSelector((state: RootState) => state.collectionDisplay.mainRuneList)
-  const dispatch = useDispatch();
-
-  const addToList = (rune: ISelectedMainRune) => {
-    dispatch(setMainRuneList([...selectedRunes, rune]));
-    localStorage.setItem("mainRunesList", JSON.stringify({ mainRunesList: [...selectedRunes, rune] }))
-  }
-
-  const removeFromList = (rune: ISelectedMainRune) => {
-    dispatch(setMainRuneList(selectedRunes.filter((obj) => obj.id !== rune.id)));
-    localStorage.setItem("mainRunesList", JSON.stringify({ mainRunesList: selectedRunes.filter((obj) => obj.id !== rune.id) }))
-  }
-
-  const isSelected = (id: number) => {
-    const rune = selectedRunes.find((rune) => rune.id === id)
-    if (!rune) return { selected: false };
-    return { selected: true }
-  }
 
   const runeBoxes = runes.map((rune) => {
     if (rune.type !== "Main") return null;
-    const isSelectedBool = isSelected(rune.id)
+
     return (
-      <RuneBox add={addToList} remove={removeFromList} isSelected={isSelectedBool} rune={rune} key={rune.id} />
+      <RuneBox rune={rune} key={rune.id} />
     )
   })
 

--- a/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
@@ -1,0 +1,68 @@
+import { runes } from "data/runes/runes"
+import { useEffect, useState } from "react"
+import { RuneIcon } from "src/components/RuneIcon/RuneIcon"
+import { IRune } from "src/types/IRune"
+
+export interface ISelectedMainRune {
+  id: number
+}
+const RuneBox = ({ rune, add, remove }: { rune: IRune, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void }) => {
+  const [selected, setSelected] = useState(false)
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: rune.id })
+    } else {
+      remove({ id: rune.id })
+    }
+  }, [selected])
+
+  const selectedClass = selected ? "" : "brightness-50"
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`}>
+      <div onClick={handleSelect}>
+        <RuneIcon rune={rune} label={true} />
+      </div>
+    </div>
+  )
+}
+
+
+export const MainRuneSelection = ({ setMainRuneList }: { setMainRuneList: (mainRuneList: ISelectedMainRune[]) => void }) => {
+  const [selectedRunes, setSelectedRunes] = useState<ISelectedMainRune[]>([])
+
+  const addToList = (rune: ISelectedMainRune) => {
+    setSelectedRunes([...selectedRunes, rune])
+  }
+
+  const removeFromList = (rune: ISelectedMainRune) => {
+    setSelectedRunes(selectedRunes.filter((obj) => obj.id !== rune.id))
+  }
+
+  const runeBoxes = runes.map((rune) => {
+    if (rune.type !== "Main") return null;
+    return (
+      <RuneBox add={addToList} remove={removeFromList} rune={rune} key={rune.id} />
+    )
+  })
+  useEffect(() => {
+    setMainRuneList(selectedRunes)
+  }, [selectedRunes]);
+
+
+  return (
+    <>
+      <div className="container-dark-inner">
+        <h1 className="text-xl">
+          Rune Selection
+        </h1>
+        <div className="flex flex-wrap gap-1">
+          {runeBoxes}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
@@ -6,8 +6,8 @@ import { IRune } from "src/types/IRune"
 export interface ISelectedMainRune {
   id: number
 }
-const RuneBox = ({ rune, add, remove }: { rune: IRune, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void }) => {
-  const [selected, setSelected] = useState(false)
+const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: { selected: boolean }, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void }) => {
+  const [selected, setSelected] = useState(isSelected.selected)
   const handleSelect = () => {
     setSelected(!selected)
   }
@@ -32,22 +32,42 @@ const RuneBox = ({ rune, add, remove }: { rune: IRune, add: (rune: ISelectedMain
 
 
 export const MainRuneSelection = ({ setMainRuneList }: { setMainRuneList: (mainRuneList: ISelectedMainRune[]) => void }) => {
-  const [selectedRunes, setSelectedRunes] = useState<ISelectedMainRune[]>([])
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("mainRunesList")
+    if (local) {
+      return JSON.parse(local).mainRunesList
+    }
+    return []
+  }
+  const [selectedRunes, setSelectedRunes] = useState<ISelectedMainRune[]>(getLocalStorage())
 
   const addToList = (rune: ISelectedMainRune) => {
     setSelectedRunes([...selectedRunes, rune])
+    localStorage.setItem("mainRunesList", JSON.stringify({ mainRunesList: [...selectedRunes, rune] }))
   }
 
   const removeFromList = (rune: ISelectedMainRune) => {
     setSelectedRunes(selectedRunes.filter((obj) => obj.id !== rune.id))
+    localStorage.setItem("mainRunesList", JSON.stringify({ mainRunesList: selectedRunes.filter((obj) => obj.id !== rune.id) }))
+  }
+
+  const isSelected = (id: number) => {
+    const rune = selectedRunes.find((rune) => rune.id === id)
+    if (!rune) return { selected: false };
+    return { selected: true }
   }
 
   const runeBoxes = runes.map((rune) => {
     if (rune.type !== "Main") return null;
+    const isSelectedBool = isSelected(rune.id)
     return (
-      <RuneBox add={addToList} remove={removeFromList} rune={rune} key={rune.id} />
+      <RuneBox add={addToList} remove={removeFromList} isSelected={isSelectedBool} rune={rune} key={rune.id} />
     )
   })
+
+
+
+
   useEffect(() => {
     setMainRuneList(selectedRunes)
   }, [selectedRunes]);

--- a/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection.tsx
@@ -2,10 +2,11 @@ import { runes } from "data/runes/runes"
 import { useEffect, useState } from "react"
 import { RuneIcon } from "src/components/RuneIcon/RuneIcon"
 import { IRune } from "src/types/IRune"
+import { ISelectedMainRune } from "types/ICollection"
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setMainRuneList } from 'src/config/redux/slices/collectionDisplaySlice'
 
-export interface ISelectedMainRune {
-  id: number
-}
 const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: { selected: boolean }, add: (rune: ISelectedMainRune) => void, remove: (rune: ISelectedMainRune) => void }) => {
   const [selected, setSelected] = useState(isSelected.selected)
   const handleSelect = () => {
@@ -31,23 +32,17 @@ const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: {
 }
 
 
-export const MainRuneSelection = ({ setMainRuneList }: { setMainRuneList: (mainRuneList: ISelectedMainRune[]) => void }) => {
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("mainRunesList")
-    if (local) {
-      return JSON.parse(local).mainRunesList
-    }
-    return []
-  }
-  const [selectedRunes, setSelectedRunes] = useState<ISelectedMainRune[]>(getLocalStorage())
+export const MainRuneSelection = () => {
+  const selectedRunes = useSelector((state: RootState) => state.collectionDisplay.mainRuneList)
+  const dispatch = useDispatch();
 
   const addToList = (rune: ISelectedMainRune) => {
-    setSelectedRunes([...selectedRunes, rune])
+    dispatch(setMainRuneList([...selectedRunes, rune]));
     localStorage.setItem("mainRunesList", JSON.stringify({ mainRunesList: [...selectedRunes, rune] }))
   }
 
   const removeFromList = (rune: ISelectedMainRune) => {
-    setSelectedRunes(selectedRunes.filter((obj) => obj.id !== rune.id))
+    dispatch(setMainRuneList(selectedRunes.filter((obj) => obj.id !== rune.id)));
     localStorage.setItem("mainRunesList", JSON.stringify({ mainRunesList: selectedRunes.filter((obj) => obj.id !== rune.id) }))
   }
 
@@ -64,14 +59,6 @@ export const MainRuneSelection = ({ setMainRuneList }: { setMainRuneList: (mainR
       <RuneBox add={addToList} remove={removeFromList} isSelected={isSelectedBool} rune={rune} key={rune.id} />
     )
   })
-
-
-
-
-  useEffect(() => {
-    setMainRuneList(selectedRunes)
-  }, [selectedRunes]);
-
 
   return (
     <>

--- a/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
@@ -1,44 +1,22 @@
 
-import { CompanionSelection } from "components/ToolsCollectionOverview/CompanionSelection/CompanionSelection"
 import { useEffect, useState } from "react"
-import { ISelectedCompanion } from "components/ToolsCollectionOverview/CompanionSelection/CompanionSelection"
-import { ISelectedSkill } from "components/ToolsCollectionOverview/SkillSelection/SkillSelection"
+import { CompanionSelection } from "components/ToolsCollectionOverview/CompanionSelection/CompanionSelection"
 import { SkillSelection } from "components/ToolsCollectionOverview/SkillSelection/SkillSelection"
-import { ISelectedMainRune } from "components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection"
 import { MainRuneSelection } from "components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection"
-import { ISelectedSubRune } from "components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection"
 import { SubRuneSelection } from "components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection"
-import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay"
-export const SelectionContainer = ({ setCollection }: { setCollection: (collection: ICollection) => void }) => {
-  const [companionList, setCompanionList] = useState<ISelectedCompanion[]>([])
-  const [skillList, setSkillList] = useState<ISelectedSkill[]>([])
-  const [mainRuneList, setMainRuneList] = useState<ISelectedMainRune[]>([])
-  const [subRuneList, setSubRuneList] = useState<ISelectedSubRune[]>([])
 
-  useEffect(() => {
-    setCollection({
-      companionsList: companionList,
-      skillList: skillList,
-      mainRuneList: mainRuneList,
-      subRuneList: subRuneList
-    })
-  }, [companionList, skillList, mainRuneList, subRuneList])
-  useEffect(() => {
-    if (localStorage.getItem("collection")) {
-      const collection = JSON.parse(localStorage.getItem("collection") || "")
-      setCollection(collection)
-    }
-  }, [])
+
+export const SelectionContainer = () => {
 
   return (
     <>
       <div className="flex flex-col lg:flex-row gap-2">
-        <CompanionSelection setCompanionList={setCompanionList} />
-        <SkillSelection setSkillList={setSkillList} />
+        <CompanionSelection />
+        <SkillSelection />
       </div>
       <div className="flex flex-col lg:flex-row gap-2">
-        <MainRuneSelection setMainRuneList={setMainRuneList} />
-        <SubRuneSelection setSubRuneList={setSubRuneList} />
+        <MainRuneSelection />
+        <SubRuneSelection />
       </div>
     </>
   )

--- a/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
@@ -28,11 +28,11 @@ export const SelectionContainer = ({ setCollection }: { setCollection: (collecti
 
   return (
     <>
-      <div className="flex flex-col lg:flex-row">
+      <div className="flex flex-col lg:flex-row gap-2">
         <CompanionSelection setCompanionList={setCompanionList} />
         <SkillSelection setSkillList={setSkillList} />
       </div>
-      <div className="flex flex-col lg:flex-row">
+      <div className="flex flex-col lg:flex-row gap-2">
         <MainRuneSelection setMainRuneList={setMainRuneList} />
         <SubRuneSelection setSubRuneList={setSubRuneList} />
       </div>

--- a/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
@@ -16,12 +16,6 @@ export const SelectionContainer = ({ setCollection }: { setCollection: (collecti
   const [subRuneList, setSubRuneList] = useState<ISelectedSubRune[]>([])
 
   useEffect(() => {
-
-
-    // localStorage.setItem("skillList", JSON.stringify({ skillList: skillList }))
-    // localStorage.setItem("mainRuneList", JSON.stringify({ mainRuneList: mainRuneList }))
-    // localStorage.setItem("subRuneList", JSON.stringify({ subRuneList: subRuneList }))
-
     setCollection({
       companionsList: companionList,
       skillList: skillList,

--- a/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
@@ -16,6 +16,12 @@ export const SelectionContainer = ({ setCollection }: { setCollection: (collecti
   const [subRuneList, setSubRuneList] = useState<ISelectedSubRune[]>([])
 
   useEffect(() => {
+
+
+    // localStorage.setItem("skillList", JSON.stringify({ skillList: skillList }))
+    // localStorage.setItem("mainRuneList", JSON.stringify({ mainRuneList: mainRuneList }))
+    // localStorage.setItem("subRuneList", JSON.stringify({ subRuneList: subRuneList }))
+
     setCollection({
       companionsList: companionList,
       skillList: skillList,
@@ -23,8 +29,12 @@ export const SelectionContainer = ({ setCollection }: { setCollection: (collecti
       subRuneList: subRuneList
     })
   }, [companionList, skillList, mainRuneList, subRuneList])
-
-
+  useEffect(() => {
+    if (localStorage.getItem("collection")) {
+      const collection = JSON.parse(localStorage.getItem("collection") || "")
+      setCollection(collection)
+    }
+  }, [])
 
   return (
     <>

--- a/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
+++ b/src/components/ToolsCollectionOverview/SelectionContainer/SelectionContainer.tsx
@@ -1,0 +1,41 @@
+
+import { CompanionSelection } from "components/ToolsCollectionOverview/CompanionSelection/CompanionSelection"
+import { useEffect, useState } from "react"
+import { ISelectedCompanion } from "components/ToolsCollectionOverview/CompanionSelection/CompanionSelection"
+import { ISelectedSkill } from "components/ToolsCollectionOverview/SkillSelection/SkillSelection"
+import { SkillSelection } from "components/ToolsCollectionOverview/SkillSelection/SkillSelection"
+import { ISelectedMainRune } from "components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection"
+import { MainRuneSelection } from "components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection"
+import { ISelectedSubRune } from "components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection"
+import { SubRuneSelection } from "components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection"
+import { ICollection } from "src/views/Tools/CollectionDisplay/CollectionDisplay"
+export const SelectionContainer = ({ setCollection }: { setCollection: (collection: ICollection) => void }) => {
+  const [companionList, setCompanionList] = useState<ISelectedCompanion[]>([])
+  const [skillList, setSkillList] = useState<ISelectedSkill[]>([])
+  const [mainRuneList, setMainRuneList] = useState<ISelectedMainRune[]>([])
+  const [subRuneList, setSubRuneList] = useState<ISelectedSubRune[]>([])
+
+  useEffect(() => {
+    setCollection({
+      companionsList: companionList,
+      skillList: skillList,
+      mainRuneList: mainRuneList,
+      subRuneList: subRuneList
+    })
+  }, [companionList, skillList, mainRuneList, subRuneList])
+
+
+
+  return (
+    <>
+      <div className="flex flex-col lg:flex-row">
+        <CompanionSelection setCompanionList={setCompanionList} />
+        <SkillSelection setSkillList={setSkillList} />
+      </div>
+      <div className="flex flex-col lg:flex-row">
+        <MainRuneSelection setMainRuneList={setMainRuneList} />
+        <SubRuneSelection setSubRuneList={setSubRuneList} />
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -61,7 +61,11 @@ export const SkillCollection = () => {
   }
 
   const removeFromList = (skill: ISelectedSkill) => {
-    dispatch(setSkillList(equippedSkills.filter((obj) => obj.id !== skill.id)));
+    const equippedSkillList = [...equippedSkills]
+    const index = equippedSkillList.findIndex((obj) => obj.id === skill.id)
+    if (index === -1) return
+    equippedSkillList[index] = {}
+    dispatch(setSkillList(equippedSkillList));
   }
 
   const isEquipped = (id: number) => {

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -65,9 +65,9 @@ export const SkillCollection = ({ skillsList, updateEquipped }: { skillsList: IS
 
 
   return (
-    <div className="container-dark-inner">
+    <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Skills</h3>
-      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-end">
+      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-center">
         {skillsList.map((skill) => {
           const isEquippedBool = isEquipped(skill.id)
           return (

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -1,0 +1,30 @@
+import { ISelectedSkill } from "../SkillSelection/SkillSelection";
+import { skills } from "src/data/skills/skills";
+import { SkillIcon } from "src/components/SkillIcon/SkillIcon";
+
+
+export const SkillCollection = ({ skillsList }: { skillsList: ISelectedSkill[] }) => {
+
+  const getSkill = (id: number) => {
+    return skills.find((skill) => skill.id === id)
+  }
+  const sortById = (a: ISelectedSkill, b: ISelectedSkill) => {
+    return a.id - b.id
+  }
+  skillsList.sort(sortById);
+
+  return (
+    <div className="container-dark-inner">
+
+      <div className="flex flex-col lg:flex-row gap-1">
+        {skillsList.map((skill) => {
+          return (
+            <div className="flex flex-col justify-center items-center w-14 m-auto" key={skill.id}>
+              <SkillIcon skill={getSkill(skill.id)} level={skill.level} label={true} />
+            </div>
+          )
+        })}
+      </div>
+    </div >
+  );
+};

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -1,7 +1,10 @@
-import { ISelectedSkill } from "../SkillSelection/SkillSelection";
+import { ISelectedSkill } from "types/ICollection";
 import { skills } from "src/data/skills/skills";
 import { SkillIcon } from "src/components/SkillIcon/SkillIcon";
 import { useEffect, useState } from "react";
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSkillList } from 'src/config/redux/slices/equipmentDisplaySlice'
 
 
 const SkillBox = ({ skill, add, remove, isEquipped }: { skill: ISelectedSkill, add: (skill: ISelectedSkill) => void, remove: (skill: ISelectedSkill) => void, isEquipped: boolean }) => {
@@ -34,51 +37,41 @@ const SkillBox = ({ skill, add, remove, isEquipped }: { skill: ISelectedSkill, a
   )
 }
 
-export const SkillCollection = ({ skillsList, updateEquipped }: { skillsList: ISelectedSkill[], updateEquipped: (type: string, list: ISelectedSkill[]) => void }) => {
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("equipped")
-    if (local) {
-      return JSON.parse(local).skillList
-    }
-    return []
-  }
-  const [equippedSkills, setEquippedSkills] = useState<ISelectedSkill[]>(getLocalStorage())
+export const SkillCollection = () => {
+  const dispatch = useDispatch();
+  const skillsList = useSelector((state: RootState) => state.collectionDisplay.skillList)
+  const equippedSkills = useSelector((state: RootState) => state.equipmentDisplay.skillList)
 
   const sortById = (a: ISelectedSkill, b: ISelectedSkill) => {
     return a.id - b.id
   }
-  skillsList.sort(sortById);
 
   const addToList = (skill: ISelectedSkill) => {
+    if (equippedSkills.some((obj) => obj.id === skill.id)) return
     const equippedSkillList = [...equippedSkills, skill]
     if (equippedSkillList.length > 6) {
       equippedSkillList.shift()
     }
-    setEquippedSkills(equippedSkillList)
+    dispatch(setSkillList(equippedSkillList));
   }
 
   const removeFromList = (skill: ISelectedSkill) => {
-    setEquippedSkills(equippedSkills.filter((obj) => obj.id !== skill.id))
+    dispatch(setSkillList(equippedSkills.filter((obj) => obj.id !== skill.id)));
   }
 
   const isEquipped = (id: number) => {
     return equippedSkills.some((skill) => skill.id === id)
   }
 
-  useEffect(() => {
-    updateEquipped("skill", equippedSkills)
-  }, [equippedSkills])
-
-
 
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Skills</h3>
       <div className="flex flex-row gap-2 flex-wrap justify-center">
-        {skillsList.map((skill) => {
+        {skillsList.toSorted(sortById).map((skill, index) => {
           const isEquippedBool = isEquipped(skill.id)
           return (
-            <SkillBox add={addToList} remove={removeFromList} skill={skill} key={skill.id} isEquipped={isEquippedBool} />
+            <SkillBox add={addToList} remove={removeFromList} skill={skill} key={index} isEquipped={isEquippedBool} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -28,7 +28,7 @@ const SkillBox = ({ skill, add, remove, isEquipped }: { skill: ISelectedSkill, a
     setSelected(isEquipped)
   }, [isEquipped])
 
-
+  if (!skill.id) return null
   return (
     <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
       {selected && <span className="absolute z-10 right-0 -top-1 text-2xl">🗸</span>}
@@ -43,14 +43,19 @@ export const SkillCollection = () => {
   const equippedSkills = useSelector((state: RootState) => state.equipmentDisplay.skillList)
 
   const sortById = (a: ISelectedSkill, b: ISelectedSkill) => {
+    if (!a.id || !b.id) return 0
     return a.id - b.id
   }
 
   const addToList = (skill: ISelectedSkill) => {
     if (equippedSkills.some((obj) => obj.id === skill.id)) return
-    const equippedSkillList = [...equippedSkills, skill]
-    if (equippedSkillList.length > 6) {
+    const equippedSkillList = [...equippedSkills]
+    const indexOfEmpty = equippedSkillList.findIndex((obj) => !obj.id)
+    if (indexOfEmpty === -1) {
       equippedSkillList.shift()
+      equippedSkillList.push(skill)
+    } else {
+      equippedSkillList[indexOfEmpty] = skill
     }
     dispatch(setSkillList(equippedSkillList));
   }
@@ -69,6 +74,7 @@ export const SkillCollection = () => {
       <h3 className="text-center min-w-48">Skills</h3>
       <div className="flex flex-row gap-2 flex-wrap justify-center">
         {skillsList.toSorted(sortById).map((skill, index) => {
+          if (!skill.id) return null
           const isEquippedBool = isEquipped(skill.id)
           return (
             <SkillBox add={addToList} remove={removeFromList} skill={skill} key={index} isEquipped={isEquippedBool} />

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -35,7 +35,14 @@ const SkillBox = ({ skill, add, remove, isEquipped }: { skill: ISelectedSkill, a
 }
 
 export const SkillCollection = ({ skillsList, updateEquipped }: { skillsList: ISelectedSkill[], updateEquipped: (type: string, list: ISelectedSkill[]) => void }) => {
-  const [equippedSkills, setEquippedSkills] = useState<ISelectedSkill[]>([])
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("equipped")
+    if (local) {
+      return JSON.parse(local).skillList
+    }
+    return []
+  }
+  const [equippedSkills, setEquippedSkills] = useState<ISelectedSkill[]>(getLocalStorage())
 
   const sortById = (a: ISelectedSkill, b: ISelectedSkill) => {
     return a.id - b.id

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -74,7 +74,7 @@ export const SkillCollection = ({ skillsList, updateEquipped }: { skillsList: IS
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Skills</h3>
-      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-center">
+      <div className="flex flex-row gap-2 flex-wrap justify-center">
         {skillsList.map((skill) => {
           const isEquippedBool = isEquipped(skill.id)
           return (

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -19,7 +19,7 @@ export const SkillCollection = ({ skillsList }: { skillsList: ISelectedSkill[] }
       <div className="flex flex-col lg:flex-row gap-1">
         {skillsList.map((skill) => {
           return (
-            <div className="flex flex-col justify-center items-center w-14 m-auto" key={skill.id}>
+            <div className="flex flex-col justify-center items-center w-12 m-auto" key={skill.id}>
               <SkillIcon skill={getSkill(skill.id)} level={skill.level} label={true} />
             </div>
           )

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -1,27 +1,77 @@
 import { ISelectedSkill } from "../SkillSelection/SkillSelection";
 import { skills } from "src/data/skills/skills";
 import { SkillIcon } from "src/components/SkillIcon/SkillIcon";
+import { useEffect, useState } from "react";
 
 
-export const SkillCollection = ({ skillsList }: { skillsList: ISelectedSkill[] }) => {
+const SkillBox = ({ skill, add, remove, isEquipped }: { skill: ISelectedSkill, add: (skill: ISelectedSkill) => void, remove: (skill: ISelectedSkill) => void, isEquipped: boolean }) => {
+  const [selected, setSelected] = useState(isEquipped)
+  const selectedClass = selected ? "brightness-125 selected-shadow" : ""
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: skill.id, level: skill.level })
+    } else {
+      remove({ id: skill.id, level: skill.level })
+    }
+  }, [selected])
 
   const getSkill = (id: number) => {
     return skills.find((skill) => skill.id === id)
   }
+  useEffect(() => {
+    setSelected(isEquipped)
+  }, [isEquipped])
+
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
+      {selected && <span className="absolute z-10 right-0 -top-1 text-2xl">🗸</span>}
+      <SkillIcon skill={getSkill(skill.id)} level={skill.level} label={true} />
+    </div>
+  )
+}
+
+export const SkillCollection = ({ skillsList, updateEquipped }: { skillsList: ISelectedSkill[], updateEquipped: (type: string, list: ISelectedSkill[]) => void }) => {
+  const [equippedSkills, setEquippedSkills] = useState<ISelectedSkill[]>([])
+
   const sortById = (a: ISelectedSkill, b: ISelectedSkill) => {
     return a.id - b.id
   }
   skillsList.sort(sortById);
 
+  const addToList = (skill: ISelectedSkill) => {
+    const equippedSkillList = [...equippedSkills, skill]
+    if (equippedSkillList.length > 6) {
+      equippedSkillList.shift()
+    }
+    setEquippedSkills(equippedSkillList)
+  }
+
+  const removeFromList = (skill: ISelectedSkill) => {
+    setEquippedSkills(equippedSkills.filter((obj) => obj.id !== skill.id))
+  }
+
+  const isEquipped = (id: number) => {
+    return equippedSkills.some((skill) => skill.id === id)
+  }
+
+  useEffect(() => {
+    updateEquipped("skill", equippedSkills)
+  }, [equippedSkills])
+
+
+
   return (
     <div className="container-dark-inner">
       <h3 className="text-center min-w-48">Skills</h3>
-      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-end">
+      <div className="flex flex-col lg:flex-row gap-2 flex-wrap justify-end">
         {skillsList.map((skill) => {
+          const isEquippedBool = isEquipped(skill.id)
           return (
-            <div className="flex flex-col justify-center items-center w-12" key={skill.id}>
-              <SkillIcon skill={getSkill(skill.id)} level={skill.level} label={true} />
-            </div>
+            <SkillBox add={addToList} remove={removeFromList} skill={skill} key={skill.id} isEquipped={isEquippedBool} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillCollection/SkillCollection.tsx
@@ -15,11 +15,11 @@ export const SkillCollection = ({ skillsList }: { skillsList: ISelectedSkill[] }
 
   return (
     <div className="container-dark-inner">
-
-      <div className="flex flex-col lg:flex-row gap-1">
+      <h3 className="text-center min-w-48">Skills</h3>
+      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-end">
         {skillsList.map((skill) => {
           return (
-            <div className="flex flex-col justify-center items-center w-12 m-auto" key={skill.id}>
+            <div className="flex flex-col justify-center items-center w-12" key={skill.id}>
               <SkillIcon skill={getSkill(skill.id)} level={skill.level} label={true} />
             </div>
           )

--- a/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
@@ -40,8 +40,8 @@ const SkillBox = ({ skill, isSelected, add, remove, update }: { skill: ISkill, i
 
 
 export const SkillSelection = () => {
-  const selectedSkills = useSelector((state: RootState) => state.collectionDisplay.skillList)
   const dispatch = useDispatch();
+  const selectedSkills = useSelector((state: RootState) => state.collectionDisplay.skillList)
 
   const addToList = (skill: ISelectedSkill) => {
     dispatch(setSkillList([...selectedSkills, skill]));
@@ -58,7 +58,7 @@ export const SkillSelection = () => {
   const isSelected = (id: number) => {
     const skill = selectedSkills.find((skill) => skill.id === id)
     if (!skill) return { selected: false, level: 1 };
-    return { selected: true, level: skill.level }
+    return { selected: true, level: skill.level || 1 }
   }
 
   const skillBoxes = skills.map((skill) => {

--- a/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
@@ -2,11 +2,12 @@ import { skills } from "data/skills/skills"
 import { useEffect, useState } from "react"
 import { SkillIcon } from "src/components/SkillIcon/SkillIcon"
 import { ISkill } from "src/types/ISkill"
+import { ISelectedSkill } from "types/ICollection"
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSkillList } from 'src/config/redux/slices/collectionDisplaySlice'
 
-export interface ISelectedSkill {
-  id: number,
-  level: number
-}
+
 const SkillBox = ({ skill, isSelected, add, remove, update }: { skill: ISkill, isSelected: { selected: boolean, level: number }, add: (skill: ISelectedSkill) => void, remove: (skill: ISelectedSkill) => void, update: (skill: ISelectedSkill) => void }) => {
   const [level, setLevel] = useState(isSelected.level)
   const [selected, setSelected] = useState(isSelected.selected)
@@ -38,34 +39,20 @@ const SkillBox = ({ skill, isSelected, add, remove, update }: { skill: ISkill, i
 }
 
 
-export const SkillSelection = ({ setSkillList }: { setSkillList: (skillList: ISelectedSkill[]) => void }) => {
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("skillsList")
-    if (local) {
-      return JSON.parse(local).skillsList
-    }
-    return []
-  }
-  const [selectedSkills, setSelectedSkills] = useState<ISelectedSkill[]>(getLocalStorage())
+export const SkillSelection = () => {
+  const selectedSkills = useSelector((state: RootState) => state.collectionDisplay.skillList)
+  const dispatch = useDispatch();
 
   const addToList = (skill: ISelectedSkill) => {
-    setSelectedSkills([...selectedSkills, skill])
-    localStorage.setItem("skillsList", JSON.stringify({ skillsList: [...selectedSkills, skill] }))
+    dispatch(setSkillList([...selectedSkills, skill]));
   }
 
   const removeFromList = (skill: ISelectedSkill) => {
-    setSelectedSkills(selectedSkills.filter((obj) => obj.id !== skill.id))
-    localStorage.setItem("skillsList", JSON.stringify({ skillsList: selectedSkills.filter((obj) => obj.id !== skill.id) }))
+    dispatch(setSkillList(selectedSkills.filter((obj) => obj.id !== skill.id)));
   }
 
   const updateList = (skill: ISelectedSkill) => {
-    setSelectedSkills(selectedSkills.map((obj) => {
-      if (obj.id === skill.id) {
-        return skill
-      }
-      return obj
-    }))
-    localStorage.setItem("skillsList", JSON.stringify({ skillsList: selectedSkills.map((obj) => { if (obj.id === skill.id) { return skill } return obj }) }))
+    dispatch(setSkillList(selectedSkills.map((obj) => obj.id === skill.id ? skill : obj)));
   }
 
   const isSelected = (id: number) => {
@@ -80,10 +67,6 @@ export const SkillSelection = ({ setSkillList }: { setSkillList: (skillList: ISe
       <SkillBox add={addToList} isSelected={isSelectedBool} remove={removeFromList} update={updateList} skill={skill} key={skill.id} />
     )
   })
-  useEffect(() => {
-    setSkillList(selectedSkills)
-  }, [selectedSkills]);
-
 
   return (
     <>

--- a/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
@@ -2,29 +2,45 @@ import { skills } from "data/skills/skills"
 import { useEffect, useState } from "react"
 import { SkillIcon } from "src/components/SkillIcon/SkillIcon"
 import { ISkill } from "src/types/ISkill"
-import { ISelectedSkill } from "types/ICollection"
 import type { RootState } from 'src/config/redux/store'
 import { useSelector, useDispatch } from 'react-redux'
 import { setSkillList } from 'src/config/redux/slices/collectionDisplaySlice'
 
 
-const SkillBox = ({ skill, isSelected, add, remove, update }: { skill: ISkill, isSelected: { selected: boolean, level: number }, add: (skill: ISelectedSkill) => void, remove: (skill: ISelectedSkill) => void, update: (skill: ISelectedSkill) => void }) => {
-  const [level, setLevel] = useState(isSelected.level)
-  const [selected, setSelected] = useState(isSelected.selected)
+const SkillBox = ({ skill }: { skill: ISkill }) => {
+  const dispatch = useDispatch();
+  const selectedSkills = useSelector((state: RootState) => state.collectionDisplay.skillList)
+  const isSelected = selectedSkills.some((obj) => obj.id === skill.id)
+  const skillFromList = selectedSkills.find((obj) => obj.id === skill.id)
+
+  const [level, setLevel] = useState(1)
+  const [selected, setSelected] = useState(isSelected)
   const handleLevelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setLevel(parseInt(event.target.value))
-    update({ id: skill.id, level: parseInt(event.target.value) })
+    const updatedSkillList = selectedSkills.map((obj) => obj.id === skill.id ? { id: skill.id, level: parseInt(event.target.value) } : obj)
+    dispatch(setSkillList(updatedSkillList));
   }
   const handleSelect = () => {
     setSelected(!selected)
   }
   useEffect(() => {
     if (selected) {
-      add({ id: skill.id, level: level })
+      if (skillFromList) {
+        dispatch(setSkillList(selectedSkills.map((obj) => obj.id === skill.id ? { id: skill.id, level: level } : obj)));
+      } else {
+        dispatch(setSkillList([...selectedSkills, { id: skill.id, level: level }]));
+      }
     } else {
-      remove({ id: skill.id, level: level })
+      dispatch(setSkillList(selectedSkills.filter((obj) => obj.id !== skill.id)));
     }
   }, [selected])
+
+  useEffect(() => {
+    setSelected(isSelected)
+    if (skillFromList) {
+      setLevel(skillFromList.level || 1)
+    }
+  }, [isSelected, skillFromList])
 
   const selectedClass = selected ? "" : "brightness-50"
 
@@ -40,31 +56,10 @@ const SkillBox = ({ skill, isSelected, add, remove, update }: { skill: ISkill, i
 
 
 export const SkillSelection = () => {
-  const dispatch = useDispatch();
-  const selectedSkills = useSelector((state: RootState) => state.collectionDisplay.skillList)
-
-  const addToList = (skill: ISelectedSkill) => {
-    dispatch(setSkillList([...selectedSkills, skill]));
-  }
-
-  const removeFromList = (skill: ISelectedSkill) => {
-    dispatch(setSkillList(selectedSkills.filter((obj) => obj.id !== skill.id)));
-  }
-
-  const updateList = (skill: ISelectedSkill) => {
-    dispatch(setSkillList(selectedSkills.map((obj) => obj.id === skill.id ? skill : obj)));
-  }
-
-  const isSelected = (id: number) => {
-    const skill = selectedSkills.find((skill) => skill.id === id)
-    if (!skill) return { selected: false, level: 1 };
-    return { selected: true, level: skill.level || 1 }
-  }
 
   const skillBoxes = skills.map((skill) => {
-    const isSelectedBool = isSelected(skill.id)
     return (
-      <SkillBox add={addToList} isSelected={isSelectedBool} remove={removeFromList} update={updateList} skill={skill} key={skill.id} />
+      <SkillBox skill={skill} key={skill.id} />
     )
   })
 

--- a/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SkillSelection/SkillSelection.tsx
@@ -1,0 +1,83 @@
+import { skills } from "data/skills/skills"
+import { useEffect, useState } from "react"
+import { SkillIcon } from "src/components/SkillIcon/SkillIcon"
+import { ISkill } from "src/types/ISkill"
+
+export interface ISelectedSkill {
+  id: number,
+  level: number
+}
+const SkillBox = ({ skill, add, remove, update }: { skill: ISkill, add: (skill: ISelectedSkill) => void, remove: (skill: ISelectedSkill) => void, update: (skill: ISelectedSkill) => void }) => {
+  const [level, setLevel] = useState(1)
+  const [selected, setSelected] = useState(false)
+  const handleLevelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setLevel(parseInt(event.target.value))
+    update({ id: skill.id, level: parseInt(event.target.value) })
+  }
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: skill.id, level: level })
+    } else {
+      remove({ id: skill.id, level: level })
+    }
+  }, [selected])
+
+  const selectedClass = selected ? "" : "brightness-50"
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`}>
+      <div onClick={handleSelect}>
+        <SkillIcon skill={skill} level={level} label={true} />
+      </div>
+      <input type="number" name="" id="" value={level} onChange={handleLevelChange} className="w-full z-10 -mt-3" />
+    </div>
+  )
+}
+
+
+export const SkillSelection = ({ setSkillList }: { setSkillList: (skillList: ISelectedSkill[]) => void }) => {
+  const [selectedSkills, setSelectedSkills] = useState<ISelectedSkill[]>([])
+
+  const addToList = (skill: ISelectedSkill) => {
+    setSelectedSkills([...selectedSkills, skill])
+  }
+
+  const removeFromList = (skill: ISelectedSkill) => {
+    setSelectedSkills(selectedSkills.filter((obj) => obj.id !== skill.id))
+  }
+
+  const updateList = (skill: ISelectedSkill) => {
+    setSelectedSkills(selectedSkills.map((obj) => {
+      if (obj.id === skill.id) {
+        return skill
+      }
+      return obj
+    }))
+  }
+
+  const skillBoxes = skills.map((skill) => {
+    return (
+      <SkillBox add={addToList} remove={removeFromList} update={updateList} skill={skill} key={skill.id} />
+    )
+  })
+  useEffect(() => {
+    setSkillList(selectedSkills)
+  }, [selectedSkills]);
+
+
+  return (
+    <>
+      <div className="container-dark-inner">
+        <h1 className="text-xl">
+          Skill Selection
+        </h1>
+        <div className="flex flex-wrap gap-1">
+          {skillBoxes}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/StringTextField/StringTextField.tsx
+++ b/src/components/ToolsCollectionOverview/StringTextField/StringTextField.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react"
+
+
+
+export const StringTextField = ({ children }: { children: string }) => {
+  const [value, setValue] = useState(children)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value)
+  }
+  useEffect(() => {
+    setValue(children)
+  }, [children])
+  return (
+    <>
+      <div className="container-light">
+        <input type="text" name="" id="" value={value} onChange={handleChange} className="h-6 bg-transparent text-black placeholder:text-gray-600" placeholder="Import/Export field.." />
+      </div>
+    </>
+  )
+
+}

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -29,7 +29,7 @@ const SubRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedSubRune,
     <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
       {selected && <>
         <span className="absolute z-10 right-0 -top-1 text-2xl">🗸</span>
-        <div className=" rounded-[50%] selected-shadow-circle border-2 border-red-400 w-14 h-14 top-2 absolute"></div>
+        <div className=" rounded-[50%] selected-shadow-circle border-2 border-red-400 w-14 h-14 top-1 absolute"></div>
       </>
       }
       <RuneIcon rune={getRune(rune.id)} label={true} />
@@ -65,9 +65,9 @@ export const SubRuneCollection = ({ runesList, updateEquipped }: { runesList: IS
   }, [equippedRunes])
 
   return (
-    <div className="container-dark-inner">
+    <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Sub Runes</h3>
-      <div className="flex flex-col lg:flex-row gap-1 flex-wrap">
+      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-center">
         {runesList.map((rune) => {
           const isEquippedBool = isEquipped(rune.id)
           return (

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -49,7 +49,7 @@ export const SubRuneCollection = ({ runesList, updateEquipped }: { runesList: IS
 
   const addToList = (rune: ISelectedSubRune) => {
     const equippedRuneList = [...equippedRunes, rune]
-    if (equippedRuneList.length > 6) {
+    if (equippedRuneList.length > 4) {
       equippedRuneList.shift()
     }
     setEquippedRunes(equippedRuneList)

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -27,7 +27,7 @@ const SubRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedSubRune,
   useEffect(() => {
     setSelected(isEquipped)
   }, [isEquipped])
-
+  if (!rune.id) return null
   return (
     <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
       {selected && <>
@@ -48,15 +48,20 @@ export const SubRuneCollection = () => {
   const equippedRunes = useSelector((state: RootState) => state.equipmentDisplay.subRuneList)
 
   const sortById = (a: ISelectedSubRune, b: ISelectedSubRune) => {
+    if (!a.id || !b.id) return 0
     return a.id - b.id
   }
 
 
   const addToList = (rune: ISelectedSubRune) => {
     if (equippedRunes.some((obj) => obj.id === rune.id)) return
-    const equippedRuneList = [...equippedRunes, rune]
-    if (equippedRuneList.length > 4) {
+    const equippedRuneList = [...equippedRunes]
+    const indexOfEmpty = equippedRuneList.findIndex((obj) => !obj.id)
+    if (indexOfEmpty === -1) {
       equippedRuneList.shift()
+      equippedRuneList.push(rune)
+    } else {
+      equippedRuneList[indexOfEmpty] = rune
     }
     dispatch(setSubRuneList(equippedRuneList));
   }
@@ -72,6 +77,7 @@ export const SubRuneCollection = () => {
       <h3 className="text-center min-w-48">Sub Runes</h3>
       <div className="flex flex-row gap-1 flex-wrap justify-center">
         {runesList.toSorted(sortById).map((rune, index) => {
+          if (!rune.id) return null
           const isEquippedBool = isEquipped(rune.id)
           return (
             <SubRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={index} />

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -66,7 +66,11 @@ export const SubRuneCollection = () => {
     dispatch(setSubRuneList(equippedRuneList));
   }
   const removeFromList = (rune: ISelectedSubRune) => {
-    dispatch(setSubRuneList(equippedRunes.filter((obj) => obj.id !== rune.id)));
+    const equippedRuneList = [...equippedRunes]
+    const index = equippedRuneList.findIndex((obj) => obj.id === rune.id)
+    if (index === -1) return
+    equippedRuneList[index] = {}
+    dispatch(setSubRuneList(equippedRuneList));
   }
   const isEquipped = (id: number) => {
     return equippedRunes.some((rune) => rune.id === id)

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -1,0 +1,28 @@
+import { ISelectedSubRune } from "../SubRuneSelection/SubRuneSelection";
+import { runes } from "data/runes/runes";
+import { RuneIcon } from "components/RuneIcon/RuneIcon";
+
+
+export const SubRuneCollection = ({ runesList }: { runesList: ISelectedSubRune[] }) => {
+  const getRune = (id: number) => {
+    return runes.find((rune) => rune.id === id)
+  }
+  const sortById = (a: ISelectedSubRune, b: ISelectedSubRune) => {
+    return a.id - b.id
+  }
+  runesList.sort(sortById);
+
+  return (
+    <div className="container-dark-inner">
+      <div className="flex flex-col lg:flex-row gap-1">
+        {runesList.map((rune) => {
+          return (
+            <div className="flex flex-col justify-center items-center w-14 m-auto" key={rune.id}>
+              <RuneIcon rune={getRune(rune.id)} label={true} />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -74,7 +74,7 @@ export const SubRuneCollection = ({ runesList, updateEquipped }: { runesList: IS
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Sub Runes</h3>
-      <div className="flex flex-col lg:flex-row gap-1 flex-wrap justify-center">
+      <div className="flex flex-row gap-1 flex-wrap justify-center">
         {runesList.map((rune) => {
           const isEquippedBool = isEquipped(rune.id)
           return (

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -1,7 +1,10 @@
-import { ISelectedSubRune } from "../SubRuneSelection/SubRuneSelection";
+import { ISelectedSubRune } from "types/ICollection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
 import { useEffect, useState } from "react";
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSubRuneList } from 'src/config/redux/slices/equipmentDisplaySlice'
 
 
 const SubRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedSubRune, add: (rune: ISelectedSubRune) => void, remove: (rune: ISelectedSubRune) => void, isEquipped: boolean }) => {
@@ -39,46 +42,39 @@ const SubRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedSubRune,
 }
 
 
-export const SubRuneCollection = ({ runesList, updateEquipped }: { runesList: ISelectedSubRune[], updateEquipped: (type: string, list: ISelectedSubRune[]) => void }) => {
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("equipped")
-    if (local) {
-      return JSON.parse(local).subRuneList
-    }
-    return []
-  }
-  const [equippedRunes, setEquippedRunes] = useState<ISelectedSubRune[]>(getLocalStorage())
+export const SubRuneCollection = () => {
+  const dispatch = useDispatch();
+  const runesList = useSelector((state: RootState) => state.collectionDisplay.subRuneList)
+  const equippedRunes = useSelector((state: RootState) => state.equipmentDisplay.subRuneList)
 
   const sortById = (a: ISelectedSubRune, b: ISelectedSubRune) => {
     return a.id - b.id
   }
-  runesList.sort(sortById);
+
 
   const addToList = (rune: ISelectedSubRune) => {
+    if (equippedRunes.some((obj) => obj.id === rune.id)) return
     const equippedRuneList = [...equippedRunes, rune]
     if (equippedRuneList.length > 4) {
       equippedRuneList.shift()
     }
-    setEquippedRunes(equippedRuneList)
+    dispatch(setSubRuneList(equippedRuneList));
   }
   const removeFromList = (rune: ISelectedSubRune) => {
-    setEquippedRunes(equippedRunes.filter((obj) => obj.id !== rune.id))
+    dispatch(setSubRuneList(equippedRunes.filter((obj) => obj.id !== rune.id)));
   }
   const isEquipped = (id: number) => {
     return equippedRunes.some((rune) => rune.id === id)
   }
-  useEffect(() => {
-    updateEquipped("subRune", equippedRunes)
-  }, [equippedRunes])
 
   return (
     <div className="container-dark-inner flex flex-col gap-3">
       <h3 className="text-center min-w-48">Sub Runes</h3>
       <div className="flex flex-row gap-1 flex-wrap justify-center">
-        {runesList.map((rune) => {
+        {runesList.toSorted(sortById).map((rune, index) => {
           const isEquippedBool = isEquipped(rune.id)
           return (
-            <SubRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={rune.id} />
+            <SubRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={index} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -40,7 +40,14 @@ const SubRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedSubRune,
 
 
 export const SubRuneCollection = ({ runesList, updateEquipped }: { runesList: ISelectedSubRune[], updateEquipped: (type: string, list: ISelectedSubRune[]) => void }) => {
-  const [equippedRunes, setEquippedRunes] = useState<ISelectedSubRune[]>([])
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("equipped")
+    if (local) {
+      return JSON.parse(local).subRuneList
+    }
+    return []
+  }
+  const [equippedRunes, setEquippedRunes] = useState<ISelectedSubRune[]>(getLocalStorage())
 
   const sortById = (a: ISelectedSubRune, b: ISelectedSubRune) => {
     return a.id - b.id

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -1,26 +1,77 @@
 import { ISelectedSubRune } from "../SubRuneSelection/SubRuneSelection";
 import { runes } from "data/runes/runes";
 import { RuneIcon } from "components/RuneIcon/RuneIcon";
+import { useEffect, useState } from "react";
 
 
-export const SubRuneCollection = ({ runesList }: { runesList: ISelectedSubRune[] }) => {
+const SubRuneBox = ({ rune, add, remove, isEquipped }: { rune: ISelectedSubRune, add: (rune: ISelectedSubRune) => void, remove: (rune: ISelectedSubRune) => void, isEquipped: boolean }) => {
+  const [selected, setSelected] = useState(isEquipped)
+  const selectedClass = selected ? "brightness-125" : ""
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: rune.id })
+    } else {
+      remove({ id: rune.id })
+    }
+  }, [selected])
+
   const getRune = (id: number) => {
     return runes.find((rune) => rune.id === id)
   }
+  useEffect(() => {
+    setSelected(isEquipped)
+  }, [isEquipped])
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`} onClick={handleSelect}>
+      {selected && <>
+        <span className="absolute z-10 right-0 -top-1 text-2xl">🗸</span>
+        <div className=" rounded-[50%] selected-shadow-circle border-2 border-red-400 w-14 h-14 top-2 absolute"></div>
+      </>
+      }
+      <RuneIcon rune={getRune(rune.id)} label={true} />
+    </div>
+  )
+
+}
+
+
+export const SubRuneCollection = ({ runesList, updateEquipped }: { runesList: ISelectedSubRune[], updateEquipped: (type: string, list: ISelectedSubRune[]) => void }) => {
+  const [equippedRunes, setEquippedRunes] = useState<ISelectedSubRune[]>([])
+
   const sortById = (a: ISelectedSubRune, b: ISelectedSubRune) => {
     return a.id - b.id
   }
   runesList.sort(sortById);
+
+  const addToList = (rune: ISelectedSubRune) => {
+    const equippedRuneList = [...equippedRunes, rune]
+    if (equippedRuneList.length > 6) {
+      equippedRuneList.shift()
+    }
+    setEquippedRunes(equippedRuneList)
+  }
+  const removeFromList = (rune: ISelectedSubRune) => {
+    setEquippedRunes(equippedRunes.filter((obj) => obj.id !== rune.id))
+  }
+  const isEquipped = (id: number) => {
+    return equippedRunes.some((rune) => rune.id === id)
+  }
+  useEffect(() => {
+    updateEquipped("subRune", equippedRunes)
+  }, [equippedRunes])
 
   return (
     <div className="container-dark-inner">
       <h3 className="text-center min-w-48">Sub Runes</h3>
       <div className="flex flex-col lg:flex-row gap-1 flex-wrap">
         {runesList.map((rune) => {
+          const isEquippedBool = isEquipped(rune.id)
           return (
-            <div className="flex flex-col justify-center items-center w-14 m-auto" key={rune.id}>
-              <RuneIcon rune={getRune(rune.id)} label={true} />
-            </div>
+            <SubRuneBox add={addToList} remove={removeFromList} isEquipped={isEquippedBool} rune={rune} key={rune.id} />
           )
         })}
       </div>

--- a/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneCollection/SubRuneCollection.tsx
@@ -14,7 +14,8 @@ export const SubRuneCollection = ({ runesList }: { runesList: ISelectedSubRune[]
 
   return (
     <div className="container-dark-inner">
-      <div className="flex flex-col lg:flex-row gap-1">
+      <h3 className="text-center min-w-48">Sub Runes</h3>
+      <div className="flex flex-col lg:flex-row gap-1 flex-wrap">
         {runesList.map((rune) => {
           return (
             <div className="flex flex-col justify-center items-center w-14 m-auto" key={rune.id}>

--- a/src/components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection.tsx
@@ -6,8 +6,8 @@ import { IRune } from "src/types/IRune"
 export interface ISelectedSubRune {
   id: number
 }
-const RuneBox = ({ rune, add, remove }: { rune: IRune, add: (rune: ISelectedSubRune) => void, remove: (rune: ISelectedSubRune) => void }) => {
-  const [selected, setSelected] = useState(false)
+const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: { selected: boolean }, add: (rune: ISelectedSubRune) => void, remove: (rune: ISelectedSubRune) => void }) => {
+  const [selected, setSelected] = useState(isSelected.selected)
   const handleSelect = () => {
     setSelected(!selected)
   }
@@ -32,20 +32,36 @@ const RuneBox = ({ rune, add, remove }: { rune: IRune, add: (rune: ISelectedSubR
 
 
 export const SubRuneSelection = ({ setSubRuneList }: { setSubRuneList: (subRuneList: ISelectedSubRune[]) => void }) => {
-  const [selectedRunes, setSelectedRunes] = useState<ISelectedSubRune[]>([])
+  const getLocalStorage = () => {
+    const local = localStorage.getItem("subRunesList")
+    if (local) {
+      return JSON.parse(local).subRunesList
+    }
+    return []
+  }
+  const [selectedRunes, setSelectedRunes] = useState<ISelectedSubRune[]>(getLocalStorage())
 
   const addToList = (rune: ISelectedSubRune) => {
     setSelectedRunes([...selectedRunes, rune])
+    localStorage.setItem("subRunesList", JSON.stringify({ subRunesList: [...selectedRunes, rune] }))
   }
 
   const removeFromList = (rune: ISelectedSubRune) => {
     setSelectedRunes(selectedRunes.filter((obj) => obj.id !== rune.id))
+    localStorage.setItem("subRunesList", JSON.stringify({ subRunesList: selectedRunes.filter((obj) => obj.id !== rune.id) }))
+  }
+
+  const isSelected = (id: number) => {
+    const rune = selectedRunes.find((rune) => rune.id === id)
+    if (!rune) return { selected: false };
+    return { selected: true }
   }
 
   const runeBoxes = runes.map((rune) => {
     if (rune.type !== "Sub") return null;
+    const isSelectedBool = isSelected(rune.id)
     return (
-      <RuneBox add={addToList} remove={removeFromList} rune={rune} key={rune.id} />
+      <RuneBox add={addToList} isSelected={isSelectedBool} remove={removeFromList} rune={rune} key={rune.id} />
     )
   })
   useEffect(() => {

--- a/src/components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection.tsx
@@ -1,0 +1,68 @@
+import { runes } from "data/runes/runes"
+import { useEffect, useState } from "react"
+import { RuneIcon } from "src/components/RuneIcon/RuneIcon"
+import { IRune } from "src/types/IRune"
+
+export interface ISelectedSubRune {
+  id: number
+}
+const RuneBox = ({ rune, add, remove }: { rune: IRune, add: (rune: ISelectedSubRune) => void, remove: (rune: ISelectedSubRune) => void }) => {
+  const [selected, setSelected] = useState(false)
+  const handleSelect = () => {
+    setSelected(!selected)
+  }
+  useEffect(() => {
+    if (selected) {
+      add({ id: rune.id })
+    } else {
+      remove({ id: rune.id })
+    }
+  }, [selected])
+
+  const selectedClass = selected ? "" : "brightness-50"
+
+  return (
+    <div className={`flex flex-col ${selectedClass} justify-center items-center w-14`}>
+      <div onClick={handleSelect}>
+        <RuneIcon rune={rune} label={true} />
+      </div>
+    </div>
+  )
+}
+
+
+export const SubRuneSelection = ({ setSubRuneList }: { setSubRuneList: (subRuneList: ISelectedSubRune[]) => void }) => {
+  const [selectedRunes, setSelectedRunes] = useState<ISelectedSubRune[]>([])
+
+  const addToList = (rune: ISelectedSubRune) => {
+    setSelectedRunes([...selectedRunes, rune])
+  }
+
+  const removeFromList = (rune: ISelectedSubRune) => {
+    setSelectedRunes(selectedRunes.filter((obj) => obj.id !== rune.id))
+  }
+
+  const runeBoxes = runes.map((rune) => {
+    if (rune.type !== "Sub") return null;
+    return (
+      <RuneBox add={addToList} remove={removeFromList} rune={rune} key={rune.id} />
+    )
+  })
+  useEffect(() => {
+    setSubRuneList(selectedRunes)
+  }, [selectedRunes]);
+
+
+  return (
+    <>
+      <div className="container-dark-inner">
+        <h1 className="text-xl">
+          Rune Selection
+        </h1>
+        <div className="flex flex-wrap gap-1">
+          {runeBoxes}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection.tsx
+++ b/src/components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection.tsx
@@ -2,10 +2,11 @@ import { runes } from "data/runes/runes"
 import { useEffect, useState } from "react"
 import { RuneIcon } from "src/components/RuneIcon/RuneIcon"
 import { IRune } from "src/types/IRune"
+import { ISelectedSubRune } from "types/ICollection"
+import type { RootState } from 'src/config/redux/store'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSubRuneList } from 'src/config/redux/slices/collectionDisplaySlice'
 
-export interface ISelectedSubRune {
-  id: number
-}
 const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: { selected: boolean }, add: (rune: ISelectedSubRune) => void, remove: (rune: ISelectedSubRune) => void }) => {
   const [selected, setSelected] = useState(isSelected.selected)
   const handleSelect = () => {
@@ -31,24 +32,16 @@ const RuneBox = ({ rune, isSelected, add, remove }: { rune: IRune, isSelected: {
 }
 
 
-export const SubRuneSelection = ({ setSubRuneList }: { setSubRuneList: (subRuneList: ISelectedSubRune[]) => void }) => {
-  const getLocalStorage = () => {
-    const local = localStorage.getItem("subRunesList")
-    if (local) {
-      return JSON.parse(local).subRunesList
-    }
-    return []
-  }
-  const [selectedRunes, setSelectedRunes] = useState<ISelectedSubRune[]>(getLocalStorage())
+export const SubRuneSelection = () => {
+  const selectedRunes = useSelector((state: RootState) => state.collectionDisplay.subRuneList)
+  const dispatch = useDispatch();
 
   const addToList = (rune: ISelectedSubRune) => {
-    setSelectedRunes([...selectedRunes, rune])
-    localStorage.setItem("subRunesList", JSON.stringify({ subRunesList: [...selectedRunes, rune] }))
+    dispatch(setSubRuneList([...selectedRunes, rune]));
   }
 
   const removeFromList = (rune: ISelectedSubRune) => {
-    setSelectedRunes(selectedRunes.filter((obj) => obj.id !== rune.id))
-    localStorage.setItem("subRunesList", JSON.stringify({ subRunesList: selectedRunes.filter((obj) => obj.id !== rune.id) }))
+    dispatch(setSubRuneList(selectedRunes.filter((obj) => obj.id !== rune.id)));
   }
 
   const isSelected = (id: number) => {
@@ -64,10 +57,6 @@ export const SubRuneSelection = ({ setSubRuneList }: { setSubRuneList: (subRuneL
       <RuneBox add={addToList} isSelected={isSelectedBool} remove={removeFromList} rune={rune} key={rune.id} />
     )
   })
-  useEffect(() => {
-    setSubRuneList(selectedRunes)
-  }, [selectedRunes]);
-
 
   return (
     <>

--- a/src/config/redux/slices/collectionDisplaySlice.ts
+++ b/src/config/redux/slices/collectionDisplaySlice.ts
@@ -1,0 +1,32 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { ICollection } from 'src/types/ICollection';
+
+const initialState: ICollection = {
+	companionsList: [],
+	skillList: [],
+	mainRuneList: [],
+	subRuneList: [],
+};
+
+export const collectionDisplaySlice = createSlice({
+	name: 'collectionDisplay',
+	initialState,
+	reducers: {
+		setCompanionsList: (state, action: PayloadAction<ICollection['companionsList']>) => {
+			state.companionsList = action.payload;
+		},
+		setSkillList: (state, action: PayloadAction<ICollection['skillList']>) => {
+			state.skillList = action.payload;
+		},
+		setMainRuneList: (state, action: PayloadAction<ICollection['mainRuneList']>) => {
+			state.mainRuneList = action.payload;
+		},
+		setSubRuneList: (state, action: PayloadAction<ICollection['subRuneList']>) => {
+			state.subRuneList = action.payload;
+		},
+	},
+});
+
+export const { setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = collectionDisplaySlice.actions;
+export default collectionDisplaySlice.reducer;

--- a/src/config/redux/slices/collectionDisplaySlice.ts
+++ b/src/config/redux/slices/collectionDisplaySlice.ts
@@ -30,9 +30,15 @@ export const collectionDisplaySlice = createSlice({
 		},
 		setSubRuneList: (state, action: PayloadAction<ICollection['subRuneList']>) => {
 			state.subRuneList = action.payload;
-		},
+    },
+    resetCollection: (state) => {
+      state.companionsList = initialState.companionsList;
+      state.skillList = initialState.skillList;
+      state.mainRuneList = initialState.mainRuneList;
+      state.subRuneList = initialState.subRuneList;
+    }
 	},
 });
 
-export const { setCollection, setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = collectionDisplaySlice.actions;
+export const { setCollection, setCompanionsList, setSkillList, setMainRuneList, setSubRuneList, resetCollection } = collectionDisplaySlice.actions;
 export default collectionDisplaySlice.reducer;

--- a/src/config/redux/slices/collectionDisplaySlice.ts
+++ b/src/config/redux/slices/collectionDisplaySlice.ts
@@ -13,6 +13,12 @@ export const collectionDisplaySlice = createSlice({
 	name: 'collectionDisplay',
 	initialState,
 	reducers: {
+		setCollection: (state, action: PayloadAction<ICollection>) => {
+			state.companionsList = action.payload.companionsList;
+			state.skillList = action.payload.skillList;
+			state.mainRuneList = action.payload.mainRuneList;
+			state.subRuneList = action.payload.subRuneList;
+		},
 		setCompanionsList: (state, action: PayloadAction<ICollection['companionsList']>) => {
 			state.companionsList = action.payload;
 		},
@@ -28,5 +34,5 @@ export const collectionDisplaySlice = createSlice({
 	},
 });
 
-export const { setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = collectionDisplaySlice.actions;
+export const { setCollection, setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = collectionDisplaySlice.actions;
 export default collectionDisplaySlice.reducer;

--- a/src/config/redux/slices/equipmentDisplaySlice.ts
+++ b/src/config/redux/slices/equipmentDisplaySlice.ts
@@ -3,10 +3,10 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { ICollection } from 'src/types/ICollection';
 
 const initialState: ICollection = {
-	companionsList: [],
-	skillList: [],
-	mainRuneList: [],
-	subRuneList: [],
+	companionsList: [{}, {}, {}, {}, {}, {}],
+	skillList: [{}, {}, {}, {}, {}, {}],
+	mainRuneList: [{}, {}, {}],
+	subRuneList: [{}, {}, {}, {}],
 };
 
 export const equipmentDisplaySlice = createSlice({

--- a/src/config/redux/slices/equipmentDisplaySlice.ts
+++ b/src/config/redux/slices/equipmentDisplaySlice.ts
@@ -13,6 +13,12 @@ export const equipmentDisplaySlice = createSlice({
 	name: 'equipmentDisplay',
 	initialState,
 	reducers: {
+		setEquipment: (state, action: PayloadAction<ICollection>) => {
+			state.companionsList = action.payload.companionsList;
+			state.skillList = action.payload.skillList;
+			state.mainRuneList = action.payload.mainRuneList;
+			state.subRuneList = action.payload.subRuneList;
+		},
 		setCompanionsList: (state, action: PayloadAction<ICollection['companionsList']>) => {
 			state.companionsList = action.payload;
 		},
@@ -28,5 +34,5 @@ export const equipmentDisplaySlice = createSlice({
 	},
 });
 
-export const { setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = equipmentDisplaySlice.actions;
+export const { setEquipment, setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = equipmentDisplaySlice.actions;
 export default equipmentDisplaySlice.reducer;

--- a/src/config/redux/slices/equipmentDisplaySlice.ts
+++ b/src/config/redux/slices/equipmentDisplaySlice.ts
@@ -1,0 +1,32 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { ICollection } from 'src/types/ICollection';
+
+const initialState: ICollection = {
+	companionsList: [],
+	skillList: [],
+	mainRuneList: [],
+	subRuneList: [],
+};
+
+export const equipmentDisplaySlice = createSlice({
+	name: 'equipmentDisplay',
+	initialState,
+	reducers: {
+		setCompanionsList: (state, action: PayloadAction<ICollection['companionsList']>) => {
+			state.companionsList = action.payload;
+		},
+		setSkillList: (state, action: PayloadAction<ICollection['skillList']>) => {
+			state.skillList = action.payload;
+		},
+		setMainRuneList: (state, action: PayloadAction<ICollection['mainRuneList']>) => {
+			state.mainRuneList = action.payload;
+		},
+		setSubRuneList: (state, action: PayloadAction<ICollection['subRuneList']>) => {
+			state.subRuneList = action.payload;
+		},
+	},
+});
+
+export const { setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = equipmentDisplaySlice.actions;
+export default equipmentDisplaySlice.reducer;

--- a/src/config/redux/slices/equipmentDisplaySlice.ts
+++ b/src/config/redux/slices/equipmentDisplaySlice.ts
@@ -30,9 +30,15 @@ export const equipmentDisplaySlice = createSlice({
 		},
 		setSubRuneList: (state, action: PayloadAction<ICollection['subRuneList']>) => {
 			state.subRuneList = action.payload;
-		},
+    },
+    resetEquipment: (state) => {
+      state.companionsList = initialState.companionsList;
+      state.skillList = initialState.skillList;
+      state.mainRuneList = initialState.mainRuneList;
+      state.subRuneList = initialState.subRuneList;
+    }
 	},
 });
 
-export const { setEquipment, setCompanionsList, setSkillList, setMainRuneList, setSubRuneList } = equipmentDisplaySlice.actions;
+export const { setEquipment, setCompanionsList, setSkillList, setMainRuneList, setSubRuneList, resetEquipment } = equipmentDisplaySlice.actions;
 export default equipmentDisplaySlice.reducer;

--- a/src/config/redux/store.ts
+++ b/src/config/redux/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import collectionDisplayReducer from 'src/config/redux/slices/collectionDisplaySlice';
+import equipmentDisplayReducer from 'src/config/redux/slices/equipmentDisplaySlice';
+
+export const store = configureStore({
+	reducer: {
+		collectionDisplay: collectionDisplayReducer,
+		equipmentDisplay: equipmentDisplayReducer,
+	},
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/config/router/router.tsx
+++ b/src/config/router/router.tsx
@@ -7,6 +7,8 @@ import { GameData } from 'views/GameData/GameData';
 import { SkillsOverview } from 'views/GameData/Skills/SkillsOverview';
 import { CompanionsOverview } from 'views/GameData/Companions/CompanionsOverview';
 import { RunesOverview } from 'views/GameData/Runes/RunesOverview';
+import { CollectionDisplay } from 'src/views/Tools/CollectionDisplay/CollectionDisplay';
+
 
 export const router = createBrowserRouter([
 	{
@@ -28,7 +30,17 @@ export const router = createBrowserRouter([
 				path: 'tools',
 				element: <Tools></Tools>,
 				children: [],
-			},
+      },
+      {
+        path: 'tools',
+        children: [
+          {
+            path: 'collection-display',
+            element: <CollectionDisplay></CollectionDisplay>,
+            children: [],
+          }
+        ]
+      },
 			{
 				path: 'game-data',
 				element: <GameData></GameData>,

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,13 @@ h1, h2, h3, span {
   0 -1px 0 #000;
 }
 
+.selected-shadow {
+  box-shadow: 0 0 5px 2px rgb(236 234 120 / 70%);
+}
+
+.selected-shadow-circle {
+  box-shadow: 0 0 5px 2px rgb(236 234 120 / 70%);
+}
 
 .background-image {
   background-image: url("./assets/sprites/background/GV_Dungeon3_background.png");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,14 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 import './styles/cat-hero-styles.css';
+import { store } from 'src/config/redux/store'
+import { Provider } from 'react-redux'
 
 const rootElement = document.getElementById('root');
 ReactDOM.createRoot(rootElement || document.createElement('div')).render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
 )

--- a/src/styles/cat-hero-styles.css
+++ b/src/styles/cat-hero-styles.css
@@ -1,11 +1,11 @@
 .container-light {
-  border: 16px solid transparent;
+  border: 10px solid transparent;
   padding: 0;
-  margin: 20px 10px;
+  margin: 15px 5px;
   background-color: #e1d4b7;
   border-image-source: url("../assets/sprites/ui/GV_mainmenu_back0513.png");
   border-image-outset: 5px;
-  border-image-slice: 30;
+  border-image-slice: 20;
   border-image-repeat: round;
   color: rgb(0 0 0 / 87%);
 
@@ -14,26 +14,26 @@
 
 
 .container-dark {
-  border: 16px solid transparent;
+  border: 5px solid transparent;
   padding: 0;
-  margin: 20px 10px;
+  margin: 15px 10px;
   color: rgb(255 255 255 / 87%);
   border-image-source: url("../assets/sprites/ui/GV_ui_main6.png");
   border-image-outset: 5px;
-  border-image-slice: 30;
+  border-image-slice: 10;
   border-image-repeat: round;
 
   background-color: #695138;
 }
 
 .container-dark-inner {
-  border: 16px solid transparent;
+  border: 5px solid transparent;
   padding: 0;
-  margin: 5px 10px;
+  margin: 5px;
   color: rgb(255 255 255 / 87%);
   border-image-source: url("../assets/sprites/ui/GV_ui_main16_1.png");
   border-image-outset: 5px;
-  border-image-slice: 30;
+  border-image-slice: 15;
   border-image-repeat: round;
 
   background-color: #392d20;

--- a/src/styles/cat-hero-styles.css
+++ b/src/styles/cat-hero-styles.css
@@ -1,6 +1,6 @@
 .container-light {
   border: 16px solid transparent;
-  padding: 10px;
+  padding: 0;
   margin: 20px 10px;
   background-color: #e1d4b7;
   border-image-source: url("../assets/sprites/ui/GV_mainmenu_back0513.png");
@@ -15,7 +15,7 @@
 
 .container-dark {
   border: 16px solid transparent;
-  padding: 10px;
+  padding: 0;
   margin: 20px 10px;
   color: rgb(255 255 255 / 87%);
   border-image-source: url("../assets/sprites/ui/GV_ui_main6.png");
@@ -28,8 +28,8 @@
 
 .container-dark-inner {
   border: 16px solid transparent;
-  padding: 10px;
-  margin: 20px 10px;
+  padding: 0;
+  margin: 5px 10px;
   color: rgb(255 255 255 / 87%);
   border-image-source: url("../assets/sprites/ui/GV_ui_main16_1.png");
   border-image-outset: 5px;
@@ -41,7 +41,7 @@
 
 .container-dark-striped {
   border: 5px solid transparent;
-  padding: 15px;
+  padding: 0;
   margin: 20px 10px;
   color: rgb(255 255 255 / 87%);
   border-image-source: url("../assets/sprites/ui/GV_ui_main12_1.png");

--- a/src/types/ICollection.ts
+++ b/src/types/ICollection.ts
@@ -1,16 +1,16 @@
 export interface ISelectedCompanion {
-	id: number;
-	level: number;
+	id?: number;
+	level?: number;
 }
 export interface ISelectedSkill {
-	id: number;
-	level: number;
+	id?: number;
+	level?: number;
 }
 export interface ISelectedSubRune {
-	id: number;
+	id?: number;
 }
 export interface ISelectedMainRune {
-	id: number;
+	id?: number;
 }
 export interface ICollection {
 	companionsList: ISelectedCompanion[];

--- a/src/types/ICollection.ts
+++ b/src/types/ICollection.ts
@@ -1,0 +1,20 @@
+export interface ISelectedCompanion {
+	id: number;
+	level: number;
+}
+export interface ISelectedSkill {
+	id: number;
+	level: number;
+}
+export interface ISelectedSubRune {
+	id: number;
+}
+export interface ISelectedMainRune {
+	id: number;
+}
+export interface ICollection {
+	companionsList: ISelectedCompanion[];
+	skillList: ISelectedSkill[];
+	mainRuneList: ISelectedMainRune[];
+	subRuneList: ISelectedSubRune[];
+}

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -1,11 +1,36 @@
 import { SubNavigationBar } from 'components/SubNavigationBar/SubNavigationBar';
 import { navigationDataTools } from 'views/Tools/subMenuData';
+import { SelectionContainer } from 'components/ToolsCollectionOverview/SelectionContainer/SelectionContainer';
+import { CollectionContainer } from 'components/ToolsCollectionOverview/CollectionContainer/CollectionContainer';
+import { useState } from 'react';
+import { ISelectedCompanion } from 'components/ToolsCollectionOverview/CompanionSelection/CompanionSelection';
+import { ISelectedSkill } from 'components/ToolsCollectionOverview/SkillSelection/SkillSelection';
+import { ISelectedMainRune } from 'components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection';
+import { ISelectedSubRune } from 'components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection';
+
+export interface ICollection {
+  companionsList: ISelectedCompanion[],
+  skillList: ISelectedSkill[],
+  mainRuneList: ISelectedMainRune[],
+  subRuneList: ISelectedSubRune[]
+}
+
+
 export const CollectionDisplay = () => {
+  const [collection, setCollection] = useState<ICollection>({
+    companionsList: [],
+    skillList: [],
+    mainRuneList: [],
+    subRuneList: []
+  })
+
   return (
     <>
       <SubNavigationBar navigationData={navigationDataTools} />
       <div className="container-dark">
         <h1>Collection Display</h1>
+        <SelectionContainer setCollection={setCollection} />
+        <CollectionContainer collection={collection} />
       </div>
     </>
   );

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -24,11 +24,23 @@ export const CollectionDisplay = () => {
     subRuneList: []
   })
 
+  const resetLocalStorage = () => {
+    localStorage.removeItem("equipped")
+    localStorage.removeItem("companionsList")
+    localStorage.removeItem("skillsList")
+    localStorage.removeItem("mainRunesList")
+    localStorage.removeItem("subRunesList")
+    location.reload()
+  }
+
   return (
     <>
       <SubNavigationBar navigationData={navigationDataTools} />
       <div className="container-dark flex flex-col gap-2">
-        <h1 className='text-2xl p-2'>Collection Display</h1>
+        <div className='flex flex-row justify-between'>
+          <h1 className='text-2xl p-2'>Collection Display</h1>
+          <button className='container-light hover:brightness-110' onClick={resetLocalStorage}>Reset</button>
+        </div>
         <SelectionContainer setCollection={setCollection} />
         <CollectionContainer collection={collection} />
       </div>

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -2,35 +2,16 @@ import { SubNavigationBar } from 'components/SubNavigationBar/SubNavigationBar';
 import { navigationDataTools } from 'views/Tools/subMenuData';
 import { SelectionContainer } from 'components/ToolsCollectionOverview/SelectionContainer/SelectionContainer';
 import { CollectionContainer } from 'components/ToolsCollectionOverview/CollectionContainer/CollectionContainer';
-import { useState } from 'react';
-import { ISelectedCompanion } from 'components/ToolsCollectionOverview/CompanionSelection/CompanionSelection';
-import { ISelectedSkill } from 'components/ToolsCollectionOverview/SkillSelection/SkillSelection';
-import { ISelectedMainRune } from 'components/ToolsCollectionOverview/MainRuneSelection/MainRuneSelection';
-import { ISelectedSubRune } from 'components/ToolsCollectionOverview/SubRuneSelection/SubRuneSelection';
+import type { RootState } from 'src/config/redux/store'
+import { useSelector } from 'react-redux'
 
-export interface ICollection {
-  companionsList: ISelectedCompanion[],
-  skillList: ISelectedSkill[],
-  mainRuneList: ISelectedMainRune[],
-  subRuneList: ISelectedSubRune[]
-}
 
 
 export const CollectionDisplay = () => {
-  const [collection, setCollection] = useState<ICollection>({
-    companionsList: [],
-    skillList: [],
-    mainRuneList: [],
-    subRuneList: []
-  })
 
-  const resetLocalStorage = () => {
-    localStorage.removeItem("equipped")
-    localStorage.removeItem("companionsList")
-    localStorage.removeItem("skillsList")
-    localStorage.removeItem("mainRunesList")
-    localStorage.removeItem("subRunesList")
-    location.reload()
+  const collection = useSelector((state: RootState) => state.collectionDisplay)
+
+  const exportString = () => {
   }
 
   return (
@@ -39,10 +20,10 @@ export const CollectionDisplay = () => {
       <div className="container-dark flex flex-col gap-2">
         <div className='flex flex-row justify-between'>
           <h1 className='text-2xl p-2'>Collection Display</h1>
-          <button className='container-light hover:brightness-110' onClick={resetLocalStorage}>Reset</button>
+          <button className='container-light hover:brightness-110' onClick={exportString}>Export</button>
         </div>
-        <SelectionContainer setCollection={setCollection} />
-        <CollectionContainer collection={collection} />
+        <SelectionContainer />
+        <CollectionContainer />
       </div>
     </>
   );

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -1,14 +1,12 @@
 import { SubNavigationBar } from 'components/SubNavigationBar/SubNavigationBar';
-import { navigationDataTools } from './subMenuData';
-
-export const Tools = () => {
+import { navigationDataTools } from 'views/Tools/subMenuData';
+export const CollectionDisplay = () => {
   return (
     <>
       <SubNavigationBar navigationData={navigationDataTools} />
-      <div className='container-dark'>
-			<h1>Tools</h1>
+      <div className="container-dark">
+        <h1>Collection Display</h1>
       </div>
     </>
-
-	);
+  );
 };

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -3,13 +3,41 @@ import { navigationDataTools } from 'views/Tools/subMenuData';
 import { SelectionContainer } from 'components/ToolsCollectionOverview/SelectionContainer/SelectionContainer';
 import { CollectionContainer } from 'components/ToolsCollectionOverview/CollectionContainer/CollectionContainer';
 import type { RootState } from 'src/config/redux/store'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
+import { setEquipment } from 'src/config/redux/slices/equipmentDisplaySlice'
+import { setCollection } from 'src/config/redux/slices/collectionDisplaySlice'
 
 
 
 export const CollectionDisplay = () => {
+  const dispatch = useDispatch();
 
   const collection = useSelector((state: RootState) => state.collectionDisplay)
+  const equipment = useSelector((state: RootState) => state.equipmentDisplay)
+  const getFromLocalStorage = () => {
+    const collection = localStorage.getItem('collection')
+    const equipment = localStorage.getItem('equipment')
+    if (collection) {
+      const collectionData = JSON.parse(collection)
+      if (collectionData) {
+        dispatch(setCollection(collectionData))
+      }
+    }
+    if (equipment) {
+      const equipmentData = JSON.parse(equipment)
+      if (equipmentData) {
+        dispatch(setEquipment(equipmentData))
+      }
+    }
+  }
+  const saveToLocalStorage = () => {
+    localStorage.setItem('collection', JSON.stringify(collection))
+    localStorage.setItem('equipment', JSON.stringify(equipment))
+  }
+
+
+
+
 
   const exportString = () => {
   }
@@ -20,7 +48,8 @@ export const CollectionDisplay = () => {
       <div className="container-dark flex flex-col gap-2">
         <div className='flex flex-row justify-between'>
           <h1 className='text-2xl p-2'>Collection Display</h1>
-          <button className='container-light hover:brightness-110' onClick={exportString}>Export</button>
+          <button className='container-light hover:brightness-110' onClick={getFromLocalStorage}>Load</button>
+          <button className='container-light hover:brightness-110' onClick={saveToLocalStorage}>Save</button>
         </div>
         <SelectionContainer />
         <CollectionContainer />

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -27,8 +27,8 @@ export const CollectionDisplay = () => {
   return (
     <>
       <SubNavigationBar navigationData={navigationDataTools} />
-      <div className="container-dark">
-        <h1>Collection Display</h1>
+      <div className="container-dark flex flex-col gap-2">
+        <h1 className='text-2xl p-2'>Collection Display</h1>
         <SelectionContainer setCollection={setCollection} />
         <CollectionContainer collection={collection} />
       </div>

--- a/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
+++ b/src/views/Tools/CollectionDisplay/CollectionDisplay.tsx
@@ -4,16 +4,18 @@ import { SelectionContainer } from 'components/ToolsCollectionOverview/Selection
 import { CollectionContainer } from 'components/ToolsCollectionOverview/CollectionContainer/CollectionContainer';
 import type { RootState } from 'src/config/redux/store'
 import { useSelector, useDispatch } from 'react-redux'
-import { setEquipment } from 'src/config/redux/slices/equipmentDisplaySlice'
-import { setCollection } from 'src/config/redux/slices/collectionDisplaySlice'
+import { setEquipment, resetEquipment } from 'src/config/redux/slices/equipmentDisplaySlice'
+import { setCollection, resetCollection } from 'src/config/redux/slices/collectionDisplaySlice'
+import { useState } from 'react';
+import { StringTextField } from 'src/components/ToolsCollectionOverview/StringTextField/StringTextField';
 
 
 
 export const CollectionDisplay = () => {
   const dispatch = useDispatch();
-
   const collection = useSelector((state: RootState) => state.collectionDisplay)
   const equipment = useSelector((state: RootState) => state.equipmentDisplay)
+  const [shareString, setShareString] = useState('')
   const getFromLocalStorage = () => {
     const collection = localStorage.getItem('collection')
     const equipment = localStorage.getItem('equipment')
@@ -34,22 +36,57 @@ export const CollectionDisplay = () => {
     localStorage.setItem('collection', JSON.stringify(collection))
     localStorage.setItem('equipment', JSON.stringify(equipment))
   }
-
-
-
-
-
   const exportString = () => {
+    const collectionString = JSON.stringify(collection);
+    const equipmentString = JSON.stringify(equipment);
+    const shareString = btoa(collectionString + "|" + equipmentString)
+    setShareString(shareString)
+  }
+
+  const importString = () => {
+    const shareString = prompt('Paste the share string here:')
+    if (shareString) {
+      const decodedShareString = atob(shareString)
+
+      const [collectionString, equipmentString] = decodedShareString.split('|')
+
+      const collectionData = JSON.parse(collectionString)
+      const equipmentData = JSON.parse(equipmentString)
+      if (collectionData) {
+        dispatch(setCollection(collectionData))
+      }
+      if (equipmentData) {
+        dispatch(setEquipment(equipmentData))
+      }
+    }
+
+  }
+
+
+  const reset = () => {
+    dispatch(resetCollection())
+    dispatch(resetEquipment())
   }
 
   return (
     <>
+
       <SubNavigationBar navigationData={navigationDataTools} />
       <div className="container-dark flex flex-col gap-2">
         <div className='flex flex-row justify-between'>
           <h1 className='text-2xl p-2'>Collection Display</h1>
-          <button className='container-light hover:brightness-110' onClick={getFromLocalStorage}>Load</button>
-          <button className='container-light hover:brightness-110' onClick={saveToLocalStorage}>Save</button>
+          <div className='flex gap-8 flex-row'>
+            <div className='flex flex-row flex-nowrap gap-2'>
+              {shareString ? <StringTextField>{shareString}</StringTextField> : <></>}
+              <button className='container-light hover:brightness-110' onClick={exportString}>Export</button>
+              <button className='container-light hover:brightness-110' onClick={importString}>Import</button>
+            </div>
+            <div className='flex flex-row flex-nowrap gap-2'>
+              <button className='container-light hover:brightness-110' onClick={getFromLocalStorage}>Load</button>
+              <button className='container-light hover:brightness-110' onClick={saveToLocalStorage}>Save</button>
+              <button className='container-light hover:brightness-110' onClick={reset}>Clear</button>
+            </div>
+          </div>
         </div>
         <SelectionContainer />
         <CollectionContainer />

--- a/src/views/Tools/subMenuData.ts
+++ b/src/views/Tools/subMenuData.ts
@@ -1,0 +1,15 @@
+import { INavigationRoute } from 'types/INavigationRoute';
+
+export const navigationDataTools: INavigationRoute = {
+	links: [
+		{
+			displayText: 'Overview',
+			url: '/tools',
+		},
+
+		{
+			displayText: 'Collection Display',
+			url: '/tools/collection-display',
+		},
+	],
+};

--- a/src/views/layouts/mainLayout.tsx
+++ b/src/views/layouts/mainLayout.tsx
@@ -7,10 +7,10 @@ export const Layout = () => {
 			<header>
 				<NavigationBar />
 			</header>
-			<main className='p-12'>
+      <main className='py-6 md:p-12'>
 				<Outlet></Outlet>
 			</main>
-			<footer className='px-12 mb-[120px]'></footer>
+      <footer className='md:px-12 mb-[120px]'></footer>
 			<div className='background-image'>
 				<div className='background-image-front'></div>
 				<div className='background-image-front-two'></div>


### PR DESCRIPTION
A tool that allows you to select items in your collection(Companions, skills, and runes), as well as selecting levels(if applicable), and then select your equipped items to have an easier time showcasing your builds in the future.

It also includes a save and load function using your localstorage. You can also export it as a string to share to other devices, and naturally an import function on top of that. 