### PR TITLE
feat/builder: Add description color parsing functionality 

### DIFF
--- a/src/components/HoverBox/DescriptionText.tsx
+++ b/src/components/HoverBox/DescriptionText.tsx
@@ -1,6 +1,10 @@
+import { useMemo } from 'react';
+
 interface StyleMapping {
   [key: string]: string;
 }
+
+type ValidStyles = 'green' | 'blue' | 'red' | 'yellow';
 
 const styleMap: StyleMapping = {
   'green': 'text-lime-500',
@@ -11,40 +15,54 @@ const styleMap: StyleMapping = {
 };
 
 export const DescriptionText = ({ description }: { description: string }) => {
-  const parseText = (text: string): (string | JSX.Element)[] => {
-    const regex = /\$\[([^\]]+)\](.*?)\[\/\]/g;
-    const parts: (string | JSX.Element)[] = [];
-    let lastIndex = 0;
-    let match;
+  const parseText = useMemo(() => {
+    const parse = (text: string): (string | JSX.Element)[] => {
+      try {
+        const regex = /\$\[([^\]]+)\](.*?)\[\/\]/g;
+        const parts: (string | JSX.Element)[] = [];
+        let lastIndex = 0;
+        let match: RegExpExecArray | null = null;
 
-    while ((match = regex.exec(text)) !== null) {
-      // Add text before the match
-      if (match.index > lastIndex) {
-        parts.push(text.slice(lastIndex, match.index));
+        while ((match = regex.exec(text)) !== null) {
+          // Handle text before the match, including any line breaks
+          if (match.index > lastIndex) {
+            const beforeText = text.slice(lastIndex, match.index);
+            const lineBreakParts = beforeText.split('\n').map((part, index, array) => {
+              return index === array.length - 1 ? part : [part, <br key={`br-${lastIndex}-${index}`} />];
+            }).flat();
+            parts.push(...lineBreakParts);
+          }
+
+          const [_, style, content] = match;
+          const className = styleMap[style as ValidStyles] || style;
+
+          parts.push(
+            <span key={match.index} className={className}>
+              {parse(content)}
+            </span>
+          );
+
+          lastIndex = regex.lastIndex;
+        }
+
+        // Handle remaining text, including any line breaks
+        if (lastIndex < text.length) {
+          const remainingText = text.slice(lastIndex);
+          const lineBreakParts = remainingText.split('\n').map((part, index, array) => {
+            return index === array.length - 1 ? part : [part, <br key={`br-end-${index}`} />];
+          }).flat();
+          parts.push(...lineBreakParts);
+        }
+
+        return parts;
+      } catch (error) {
+        console.error('Error parsing description text:', error);
+        return [text]; // Fallback to raw text on error
       }
+    };
 
-      const [_, style, content] = match;
-      const className = styleMap[style] || style; // Use mapping or raw class name
+    return parse(description);
+  }, [description]);
 
-      // Add styled content
-      parts.push(
-        <span key={match.index} className={className}>
-          {parseText(content)} {/* Recursive call for nested tags */}
-        </span>
-      );
-
-      lastIndex = regex.lastIndex;
-    }
-
-    // Add remaining text
-    if (lastIndex < text.length) {
-      parts.push(text.slice(lastIndex));
-    }
-
-    return parts;
-  };
-
-  const parsedDescription = parseText(description);
-
-  return <>{parsedDescription}</>;
+  return <>{parseText}</>;
 };

--- a/src/components/HoverBox/DescriptionText.tsx
+++ b/src/components/HoverBox/DescriptionText.tsx
@@ -1,0 +1,50 @@
+interface StyleMapping {
+  [key: string]: string;
+}
+
+const styleMap: StyleMapping = {
+  'green': 'text-lime-500',
+  'blue': 'text-blue-400',
+  'red': 'text-red-500',
+  'yellow': 'text-amber-400',
+  // Add more color mappings as needed
+};
+
+export const DescriptionText = ({ description }: { description: string }) => {
+  const parseText = (text: string): (string | JSX.Element)[] => {
+    const regex = /\$\[([^\]]+)\](.*?)\[\/\]/g;
+    const parts: (string | JSX.Element)[] = [];
+    let lastIndex = 0;
+    let match;
+
+    while ((match = regex.exec(text)) !== null) {
+      // Add text before the match
+      if (match.index > lastIndex) {
+        parts.push(text.slice(lastIndex, match.index));
+      }
+
+      const [_, style, content] = match;
+      const className = styleMap[style] || style; // Use mapping or raw class name
+
+      // Add styled content
+      parts.push(
+        <span key={match.index} className={className}>
+          {parseText(content)} {/* Recursive call for nested tags */}
+        </span>
+      );
+
+      lastIndex = regex.lastIndex;
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+      parts.push(text.slice(lastIndex));
+    }
+
+    return parts;
+  };
+
+  const parsedDescription = parseText(description);
+
+  return <>{parsedDescription}</>;
+};

--- a/src/components/HoverBox/HoverContainer.tsx
+++ b/src/components/HoverBox/HoverContainer.tsx
@@ -10,9 +10,9 @@ import { ReactNode, useEffect, useRef, useState } from 'react';
 export const HoverContainer = ({ children, type }: { children: ReactNode, type?: string }) => {
   const ref = useRef(null);
   const isVisible = useIsVisible({ ref });
-  const bottomOffset = type === 'skill' ? '-bottom-[4.5rem]' : type === "sub-rune" ? "-bottom-[4.5rem]" : type === "main-rune" ? '' : '-bottom-[6.5rem]';
+  const bottomOffset = type === 'skill' ? '-bottom-[5.5rem]' : type === "sub-rune" ? "-bottom-[4.5rem]" : type === "main-rune" ? '' : '-bottom-[6.5rem]';
 
-  const translateVerticalValue = isVisible[0] ? '-translate-y-full -top-4 hover-box-top' : 'translate-y-full hover-box-bottom ' + bottomOffset;
+  const translateVerticalValue = isVisible[0] ? '-translate-y-full -top-4 hover-box-top' : 'translate-y-full -top-16 hover-box-bottom ' + bottomOffset;
   const translateHorizontal = isVisible[1] && isVisible[2] ? '-translate-x-1/2' : isVisible[1] ? '-translate-x-[85%]' : isVisible[2] ? '-translate-x-[15%]' : '-translate-x-1/2';
 
   return (

--- a/src/components/HoverBox/SkillHoverBox.tsx
+++ b/src/components/HoverBox/SkillHoverBox.tsx
@@ -6,6 +6,7 @@ import { SkillIcon } from "../SkillIcon/SkillIcon";
 import { getDeviceType } from "src/utility/device/getDevice";
 import { IHoverBox } from "src/types/IHoverBox";
 import Game from "types/game";
+import { DescriptionText } from "./DescriptionText";
 /**
  * Hover box for the skill
  * @param {ISkill} skill - The skill object
@@ -44,7 +45,7 @@ export const HoverBox = forwardRef(({ skill }: { skill: Game.Skill }, ref: Ref<I
           <div className="flex flex-col">
             <TypesList types={skill.types} />
             <div className="text-[0.6rem] p-2 m-1 mb-2 rounded-md hover-type">
-              <span>{skill.description}</span>
+              <span><DescriptionText description={skill.description} /></span>
             </div>
           </div>
         </div>

--- a/src/components/HoverBox/SkillHoverBox.tsx
+++ b/src/components/HoverBox/SkillHoverBox.tsx
@@ -27,7 +27,32 @@ export const HoverBox = forwardRef(({ skill }: { skill: Game.Skill }, ref: Ref<I
       setIsVisible(false);
     }
   }));
-
+  // remove the $[]] and [/] from the description
+  const cleanDescription = skill.description ? skill.description.replace(/\$\[([^\]]+)\](.*?)\[\/\]/g, '') : '';
+  const heightValue = cleanDescription.length + ((cleanDescription.split('\n').length - 1) * 30);
+  const heightClass = function (height: number) {
+    if (height < 140) {
+      return "h-40";
+    } else if (height < 210) {
+      return "h-48";
+    } else if (height < 280) {
+      return "h-52";
+    } else if (height < 350) {
+      return "h-60";
+    } else if (height < 420) {
+      return "h-64";
+    } else if (height < 490) {
+      return "h-72";
+    } else if (height < 560) {
+      return "h-80";
+    } else if (height < 630) {
+      return "h-88";
+    } else if (height < 700) {
+      return "h-96";
+    } else {
+      return "h-104";
+    }
+  }
   if (!isVisible) {
     return (
       <>
@@ -35,8 +60,8 @@ export const HoverBox = forwardRef(({ skill }: { skill: Game.Skill }, ref: Ref<I
   }
   return (
     <HoverContainer type="skill">
-      <div className='hover-box hover-box-skill flex justify-center items-start h-52 w-72' onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
-        <Ribbon width={"large"}>{skill.name}</Ribbon>
+      <div className={`hover-box hover-box-skill flex justify-center items-start ${heightClass(heightValue)} w-72`} onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
+        <Ribbon width={"large"}>{skill.name + " " + heightValue}</Ribbon>
         <div className='flex flex-row justify-between items-start translate-y-12 mt-1 gap-2 w-64'>
           <div>
             <SkillIcon skill={skill} label={false} />

--- a/src/components/HoverBox/SkillHoverBox.tsx
+++ b/src/components/HoverBox/SkillHoverBox.tsx
@@ -61,7 +61,7 @@ export const HoverBox = forwardRef(({ skill }: { skill: Game.Skill }, ref: Ref<I
   return (
     <HoverContainer type="skill">
       <div className={`hover-box hover-box-skill flex justify-center items-start ${heightClass(heightValue)} w-72`} onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
-        <Ribbon width={"large"}>{skill.name + " " + heightValue}</Ribbon>
+        <Ribbon width={"large"}>{skill.name}</Ribbon>
         <div className='flex flex-row justify-between items-start translate-y-12 mt-1 gap-2 w-64'>
           <div>
             <SkillIcon skill={skill} label={false} />

--- a/src/components/HoverBox/mainRuneHoverBox.tsx
+++ b/src/components/HoverBox/mainRuneHoverBox.tsx
@@ -5,6 +5,7 @@ import { RuneIcon } from "../RuneIcon/RuneIcon";
 import { getDeviceType } from "src/utility/device/getDevice";
 import { IHoverBox } from "src/types/IHoverBox";
 import Game from "types/game";
+import { DescriptionText } from "./DescriptionText";
 /**
  * Hover box for the main rune
  * @param {IMainRune} rune - The main rune object
@@ -42,7 +43,7 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.MainRune }, ref:
           </div>
           <div className="flex flex-col">
             <div className="text-[0.6rem] p-2 m-1 mb-2 rounded-md hover-type">
-              <span>{rune.description}</span>
+              <span><DescriptionText description={rune.description} /></span>
             </div>
           </div>
         </div>

--- a/src/components/HoverBox/mainRuneHoverBox.tsx
+++ b/src/components/HoverBox/mainRuneHoverBox.tsx
@@ -50,7 +50,7 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.MainRune }, ref:
   return (
     <HoverContainer type="main-rune">
       <div className={`hover-box hover-box-main-rune flex justify-center items-start ${heightClass(heightValue)} w-64`} onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
-        <Ribbon width={"medium"}>{rune.name + " " + heightValue}</Ribbon>
+        <Ribbon width={"medium"}>{rune.name}</Ribbon>
         <div className='flex flex-row justify-between items-start translate-y-12 mt-1 gap-2 w-56'>
           <div>
             <RuneIcon type="main" rune={rune} label={false} />

--- a/src/components/HoverBox/mainRuneHoverBox.tsx
+++ b/src/components/HoverBox/mainRuneHoverBox.tsx
@@ -28,6 +28,20 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.MainRune }, ref:
     }
   }));
 
+  const heightValue = rune.description.length + ((rune.description.split('\n').length - 1) * 30);
+  const heightClass = function (height: number) {
+    if (height < 80) {
+      return "h-32";
+    } else if (height < 120) {
+      return "h-36";
+    } else if (height < 160) {
+      return "h-44";
+    } else if (height < 310) {
+      return "h-48";
+    } else if (height < 420) {
+      return "h-52";
+    }
+  }
   if (!isVisible) {
     return (
       <>
@@ -35,8 +49,8 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.MainRune }, ref:
   }
   return (
     <HoverContainer type="main-rune">
-      <div className='hover-box hover-box-main-rune flex justify-center items-start h-48 w-64' onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
-        <Ribbon width={"medium"}>{rune.name}</Ribbon>
+      <div className={`hover-box hover-box-main-rune flex justify-center items-start ${heightClass(heightValue)} w-64`} onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
+        <Ribbon width={"medium"}>{rune.name + " " + heightValue}</Ribbon>
         <div className='flex flex-row justify-between items-start translate-y-12 mt-1 gap-2 w-56'>
           <div>
             <RuneIcon type="main" rune={rune} label={false} />

--- a/src/components/HoverBox/subRuneHoverBox.tsx
+++ b/src/components/HoverBox/subRuneHoverBox.tsx
@@ -26,6 +26,22 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.SubRune }, ref: 
       setIsVisible(false);
     }
   }));
+  const heightValue = rune.description.length + ((rune.description.split('\n').length - 1) * 30);
+  const heightClass = function (height: number) {
+    if (height < 65) {
+      return "h-32";
+    } else if (height < 85) {
+      return "h-36";
+    } else if (height < 100) {
+      return "h-40";
+    } else if (height < 120) {
+      return "h-44";
+    } else if (height < 140) {
+      return "h-48";
+    } else {
+      return "h-52";
+    }
+  }
 
   if (!isVisible) {
     return (
@@ -34,8 +50,8 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.SubRune }, ref: 
   }
   return (
     <HoverContainer type="sub-rune">
-      <div className='hover-box hover-box-sub-rune flex justify-center items-start h-36 w-56' onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
-        <Ribbon width={""}>{rune.name}</Ribbon>
+      <div className={`hover-box hover-box-sub-rune flex justify-center items-start ${heightClass(heightValue)} w-56`} onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
+        <Ribbon width={""}>{rune.name + " " + heightValue}</Ribbon>
         <div className='flex flex-row justify-between items-start translate-y-12 mt-1 gap-2 w-48'>
           <div>
             <RuneIcon type="sub" rune={rune} label={false} />

--- a/src/components/HoverBox/subRuneHoverBox.tsx
+++ b/src/components/HoverBox/subRuneHoverBox.tsx
@@ -51,7 +51,7 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.SubRune }, ref: 
   return (
     <HoverContainer type="sub-rune">
       <div className={`hover-box hover-box-sub-rune flex justify-center items-start ${heightClass(heightValue)} w-56`} onMouseOver={() => { clearTimeout(hoverTimeout); setIsVisible(false); }}>
-        <Ribbon width={""}>{rune.name + " " + heightValue}</Ribbon>
+        <Ribbon width={""}>{rune.name}</Ribbon>
         <div className='flex flex-row justify-between items-start translate-y-12 mt-1 gap-2 w-48'>
           <div>
             <RuneIcon type="sub" rune={rune} label={false} />

--- a/src/components/HoverBox/subRuneHoverBox.tsx
+++ b/src/components/HoverBox/subRuneHoverBox.tsx
@@ -5,7 +5,7 @@ import { RuneIcon } from "../RuneIcon/RuneIcon";
 import { getDeviceType } from "src/utility/device/getDevice";
 import { IHoverBox } from "src/types/IHoverBox";
 import Game from "types/game";
-
+import { DescriptionText } from "./DescriptionText";
 /**
  * Hover box for the sub rune
  * @param {ISubRune} rune - The sub rune object
@@ -42,7 +42,7 @@ export const HoverBox = forwardRef(({ rune }: { rune: Game.Rune.SubRune }, ref: 
           </div>
           <div className="flex flex-col">
             <div className="text-[0.6rem] p-2 m-1 mb-2 rounded-md hover-type">
-              <span>{rune.description}</span>
+              <span><DescriptionText description={rune.description} /></span>
             </div>
           </div>
         </div>

--- a/src/styles/cat-hero-styles.css
+++ b/src/styles/cat-hero-styles.css
@@ -158,11 +158,11 @@
   animation: scale-increase 0.25s ease-out;
 }
 
-.hover-box-top div {
+.hover-box-top {
   transform-origin: bottom;
 }
 
-.hover-box-bottom div {
+.hover-box-bottom {
   transform-origin: top;
 }
 

--- a/src/views/News/News.tsx
+++ b/src/views/News/News.tsx
@@ -76,7 +76,6 @@ export const News = () => {
     }
     setSelectedType('all');
   }, []);
-
   return (
     <div>
       <div className='container-dark'>
@@ -89,7 +88,7 @@ export const News = () => {
             {radioBackground}
           </div>
         </div>
-        {newsData && newsData.data.length > 0 ? <NewsList {...newsData} /> : fetched ? <h1>No news found</h1> : <h1>Loading...</h1>}
+        {newsData && newsData.data?.length > 0 ? <NewsList {...newsData} /> : fetched ? <h1>No news found</h1> : <h1>Loading...</h1>}
       </div>
     </div>
   );


### PR DESCRIPTION
Adds ability to add styling to the description texts for skills and runes.

It enables us to create description that are easier to read at a glance, and emphasis on the relevant parts of the descriptions.

It's accessible by specifying a start point and end point of a styling in the description text like this:
`Increases the skill DMG by $[green]1000%[/] for $[green]10 seconds[/].`
The `$[*]` specifies the start point of the styling, and in this case, `green` is the keyword for the styling which will make the color green.
To specify where it ends, you write `[/]`
The specific syntax is chosen to ensure that it doesn't clash with any existing formatting we have, and should be unique enough to not cause issues in most ways.

Currently, it supports the following colors:
`green`: The most commonly used color, which is often used to specify numbers in the texts, such as damage numbers, durations, or quantities. 
`blue`: Mostly used for "Wolf CRIT", but also some other parts such as Whale Fleet's description when it specifies the different type of skills it casts.
`yellow`: Used for the "Unique" description text on skills.
`red`: Not used in game, but added just for the sake of having it.

If changes are needed to these, or additional stylings are needed, it can be found in the `DescriptionText.tsx` file in `./src/components/hoverBox/` folder.

I am looking into perhaps extracting some of the logic related to it to it's own utility function, to add more ability to parse text like this elsewhere, but for now it remains here as it is exclusively for these hover texts.

Additionally, the height of the hover boxes should be more adaptive to the size of the content. It's a very hacky implementation, so I will be observing the result and see if it needs adjustments.